### PR TITLE
Use byte array for data passed in on_event callback. #5

### DIFF
--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -28,7 +28,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   public
   def decode(data)
-    datum = StringIO.new(data)
+    datum = StringIO.new(String.from_java_bytes(data))
     decoder = Avro::IO::BinaryDecoder.new(datum)
     datum_reader = Avro::IO::DatumReader.new(@schema)
     yield LogStash::Event.new(datum_reader.read(decoder))
@@ -40,6 +40,6 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
     dw.write(event.to_hash, encoder)
-    @on_event.call(event, buffer.string)
+    @on_event.call(event, buffer.string.to_java_bytes)
   end
 end

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -24,8 +24,9 @@ describe LogStash::Codecs::Avro do
       buffer = StringIO.new
       encoder = Avro::IO::BinaryEncoder.new(buffer)
       dw.write(test_event.to_hash, encoder)
+      payload = buffer.string.to_java_bytes
 
-      subject.decode(buffer.string) do |event|
+      subject.decode(payload) do |event|
         insist { event.is_a? LogStash::Event }
         insist { event["foo"] } == test_event["foo"]
         insist { event["bar"] } == test_event["bar"]
@@ -38,7 +39,7 @@ describe LogStash::Codecs::Avro do
       got_event = false
       subject.on_event do |event, data|
         schema = Avro::Schema.parse(avro_config['schema_uri'])
-        datum = StringIO.new(data)
+        datum = StringIO.new(String.from_java_bytes(data))
         decoder = Avro::IO::BinaryDecoder.new(datum)
         datum_reader = Avro::IO::DatumReader.new(schema)
         record = datum_reader.read(decoder)


### PR DESCRIPTION
Convert data to and from byte array #5

This patch introduce jruby-specific methods and breaks compatibility with MRI. I'm not sure about this approach so feedback is appreciated. 
