### PR TITLE
adding support for stripping magic byte and schema id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.1
+- add support for decoding Kafka events with Magic Byte and Schema Id headers
+
 ## 3.0.0
  - breaking: Update to new Event API
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -49,6 +49,7 @@ input {
     topic_id => 'test_topic'
       codec => avro {
         schema_uri => 'tweet.avsc'
+        strip_headers => false
       }
   }
 }

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -61,7 +61,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   # strip the magic byte and schema_id from the message
   # defaults to false
-  config :strip_headers, :validate => :string, :default => "false"
+  config :strip_headers, :validate => :boolean, :default => false
 
   def open_and_read(uri_string)
     open(uri_string).read
@@ -76,7 +76,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   def decode(data)
     datum = StringIO.new(data)
 
-    if strip_headers == "true"
+    if strip_headers
       if data.length < 5
         @logger.error('message is too small to decode')
       end
@@ -85,6 +85,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
         @logger.error('message does not start with magic byte')
       end
     end
+
+    # can still get to here with strip headers true
 
     decoder = Avro::IO::BinaryDecoder.new(datum)
     datum_reader = Avro::IO::DatumReader.new(@schema)

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.0.0'
+  s.version         = '3.0.1'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Encode and decode avro formatted data"

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -69,7 +69,7 @@ describe LogStash::Codecs::Avro do
         dw = Avro::IO::DatumWriter.new(schema)
         buffer = StringIO.new
 
-        headers = [MAGIC_BYTE,1234]
+        headers = [LogStash::Codecs::Avro::MAGIC_BYTE,1234]
         header = headers.pack("cI>")
         buffer.write(header)
 

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -14,7 +14,7 @@ describe LogStash::Codecs::Avro do
   let(:config) {
     {
         "schema_uri" => avro_config['schema_uri'],
-        "strip_headers" => "false",
+        "strip_headers" => false,
     }
   }
 
@@ -55,7 +55,7 @@ describe LogStash::Codecs::Avro do
       let(:settings) {
         {
             "schema_uri" => avro_config['schema_uri'],
-            "strip_headers" => "true",
+            "strip_headers" => true,
         }
       }
       subject do

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -68,10 +68,14 @@ describe LogStash::Codecs::Avro do
         schema = Avro::Schema.parse(avro_config['schema_uri'])
         dw = Avro::IO::DatumWriter.new(schema)
         buffer = StringIO.new
+
+        headers = [MAGIC_BYTE,1234]
+        header = headers.pack("cI>")
+        buffer.write(header)
+
         encoder = Avro::IO::BinaryEncoder.new(buffer)
         dw.write(test_event.to_hash, encoder)
         got_event = false
-
 
         subject.decode(buffer.string) do |event|
           insist { event.is_a? LogStash::Event }

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -11,24 +11,76 @@ describe LogStash::Codecs::Avro do
                                    {"name": "bar", "type": "int"}]}'}}
   let (:test_event) { LogStash::Event.new({"foo" => "hello", "bar" => 10}) }
 
+  let(:config) {
+    {
+        "schema_uri" => avro_config['schema_uri'],
+        "strip_headers" => "false",
+    }
+  }
+
   subject do
     allow_any_instance_of(LogStash::Codecs::Avro).to \
       receive(:open_and_read).and_return(avro_config['schema_uri'])
-    next LogStash::Codecs::Avro.new(avro_config)
+    next LogStash::Codecs::Avro.new(config)
   end
 
-  context "#decode" do
-    it "should return an LogStash::Event from avro data" do
-      schema = Avro::Schema.parse(avro_config['schema_uri'])
-      dw = Avro::IO::DatumWriter.new(schema)
-      buffer = StringIO.new
-      encoder = Avro::IO::BinaryEncoder.new(buffer)
-      dw.write(test_event.to_hash, encoder)
+  describe "#decode" do
+    subject do
+      allow_any_instance_of(LogStash::Codecs::Avro).to \
+      receive(:open_and_read).and_return(avro_config['schema_uri'])
+      next LogStash::Codecs::Avro.new(config)
+    end
 
-      subject.decode(buffer.string) do |event|
-        insist { event.is_a? LogStash::Event }
-        insist { event.get("foo") } == test_event.get("foo")
-        insist { event.get("bar") } == test_event.get("bar")
+    context "with strip headers false" do
+      it "should return an LogStash::Event from avro data" do
+        schema = Avro::Schema.parse(avro_config['schema_uri'])
+        dw = Avro::IO::DatumWriter.new(schema)
+        buffer = StringIO.new
+        encoder = Avro::IO::BinaryEncoder.new(buffer)
+        dw.write(test_event.to_hash, encoder)
+        got_event = false
+
+        subject.decode(buffer.string) do |event|
+          insist { event.is_a? LogStash::Event }
+          insist { event.get("foo") } == test_event.get("foo")
+          insist { event.get("bar") } == test_event.get("bar")
+          got_event = true
+        end
+
+        insist { got_event }
+      end
+    end
+
+    context "with strip headers true" do
+      let(:settings) {
+        {
+            "schema_uri" => avro_config['schema_uri'],
+            "strip_headers" => "true",
+        }
+      }
+      subject do
+        allow_any_instance_of(LogStash::Codecs::Avro).to \
+        receive(:open_and_read).and_return(avro_config['schema_uri'])
+        next LogStash::Codecs::Avro.new(settings)
+      end
+
+      it "should return an LogStash::Event from avro data and strip headers" do
+        schema = Avro::Schema.parse(avro_config['schema_uri'])
+        dw = Avro::IO::DatumWriter.new(schema)
+        buffer = StringIO.new
+        encoder = Avro::IO::BinaryEncoder.new(buffer)
+        dw.write(test_event.to_hash, encoder)
+        got_event = false
+
+
+        subject.decode(buffer.string) do |event|
+          insist { event.is_a? LogStash::Event }
+          insist { event.get("foo") } == test_event.get("foo")
+          insist { event.get("bar") } == test_event.get("bar")
+          got_event = true
+        end
+
+        insist { got_event }
       end
     end
   end


### PR DESCRIPTION
Support for stripping magic byte and schema id

When using Avro schema to post to Kafka topic, the messages all have five byte header (magic byte + 4 bytes for schema id).  When using avro codec, these bytes need to be stripped off before trying to decode the message.  The strip_header config triggers this behavior.
