### PR TITLE
add tag_on_failure option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+ - Introduce `tag_on_failure` option to tag events with `_avroparsefailure` instead of throwing an exception when decoding
+
 ## 3.0.0
  - breaking: Update to new Event API
 

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.0.0'
+  s.version         = '3.1.0'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Encode and decode avro formatted data"

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -31,6 +31,21 @@ describe LogStash::Codecs::Avro do
         insist { event.get("bar") } == test_event.get("bar")
       end
     end
+
+    it "should throw exception if decoding fails" do
+      expect { subject.decode("not avro") { |_| } }.to raise_error NoMethodError
+    end
+  end
+
+  context "#decode with tag_on_failure" do
+    let (:avro_config) { super.merge("tag_on_failure" => true) }
+
+    it "should tag event on failure" do
+      subject.decode("not avro") do |event|
+        insist { event.is_a? LogStash::Event }
+        insist { event.get("tags") } == ["_avroparsefailure"]
+      end
+    end
   end
 
   context "#encode" do


### PR DESCRIPTION
Add the ability to set a `tag_on_failure` config param to tag an event with `_avroparsefailure` and setting `message` field as the raw event that was unparseable.