### PR TITLE
#5 #12 Binary Codec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 Gemfile.lock
 .bundle
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+ - Fixed an issue with the encoding that prevented certain fields from being serialized in a way compatible with the Kafka plugins
+
 ## 3.1.0
  - Introduce `tag_on_failure` option to tag events with `_avroparsefailure` instead of throwing an exception when decoding
 

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -71,7 +71,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   public
   def decode(data)
-    datum = StringIO.new(Base64.strict_decode64(data))
+    datum = StringIO.new(Base64.strict_decode64(data)) rescue StringIO.new(data)
     decoder = Avro::IO::BinaryDecoder.new(datum)
     datum_reader = Avro::IO::DatumReader.new(@schema)
     yield LogStash::Event.new(datum_reader.read(decoder))

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "open-uri"
 require "avro"
+require "base64"
 require "logstash/codecs/base"
 require "logstash/event"
 require "logstash/timestamp"
@@ -70,7 +71,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   public
   def decode(data)
-    datum = StringIO.new(data)
+    datum = StringIO.new(Base64.strict_decode64(data))
     decoder = Avro::IO::BinaryDecoder.new(datum)
     datum_reader = Avro::IO::DatumReader.new(@schema)
     yield LogStash::Event.new(datum_reader.read(decoder))
@@ -89,6 +90,6 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
     dw.write(event.to_hash, encoder)
-    @on_event.call(event, buffer.string)
+    @on_event.call(event, Base64.strict_encode64(buffer.string))
   end
 end

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.1.0'
+  s.version         = '3.2.0'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Encode and decode avro formatted data"

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -21,7 +21,7 @@ describe LogStash::Codecs::Avro do
     end
 
     context "#decode" do
-      it "should return an LogStash::Event from avro data" do
+      it "should return an LogStash::Event from raw and base64 encoded avro data" do
         schema = Avro::Schema.parse(avro_config['schema_uri'])
         dw = Avro::IO::DatumWriter.new(schema)
         buffer = StringIO.new
@@ -33,10 +33,15 @@ describe LogStash::Codecs::Avro do
           insist {event.get("foo")} == test_event.get("foo")
           insist {event.get("bar")} == test_event.get("bar")
         end
+        subject.decode(buffer.string) do |event|
+          insist {event.is_a? LogStash::Event}
+          insist {event.get("foo")} == test_event.get("foo")
+          insist {event.get("bar")} == test_event.get("bar")
+        end
       end
 
       it "should throw exception if decoding fails" do
-        expect {subject.decode("not avro") {|_| }}.to raise_error ArgumentError
+        expect {subject.decode("not avro") {|_| }}.to raise_error NoMethodError
       end
     end
 

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -1,70 +1,109 @@
 # encoding: utf-8
-require "logstash/devutils/rspec/spec_helper"
+require 'logstash/devutils/rspec/spec_helper'
 require 'avro'
+require 'base64'
 require 'logstash/codecs/avro'
 require 'logstash/event'
 
 describe LogStash::Codecs::Avro do
-  let (:avro_config) {{'schema_uri' => '
+
+  context "non binary data" do
+    let (:avro_config) {{ 'schema_uri' => '
                         {"type": "record", "name": "Test",
                         "fields": [{"name": "foo", "type": ["null", "string"]},
-                                   {"name": "bar", "type": "int"}]}'}}
-  let (:test_event) { LogStash::Event.new({"foo" => "hello", "bar" => 10}) }
+                                   {"name": "bar", "type": "int"}]}' }}
+    let (:test_event) {LogStash::Event.new({ "foo" => "hello", "bar" => 10 })}
 
-  subject do
-    allow_any_instance_of(LogStash::Codecs::Avro).to \
+    subject do
+      allow_any_instance_of(LogStash::Codecs::Avro).to \
       receive(:open_and_read).and_return(avro_config['schema_uri'])
-    next LogStash::Codecs::Avro.new(avro_config)
-  end
-
-  context "#decode" do
-    it "should return an LogStash::Event from avro data" do
-      schema = Avro::Schema.parse(avro_config['schema_uri'])
-      dw = Avro::IO::DatumWriter.new(schema)
-      buffer = StringIO.new
-      encoder = Avro::IO::BinaryEncoder.new(buffer)
-      dw.write(test_event.to_hash, encoder)
-
-      subject.decode(buffer.string) do |event|
-        insist { event.is_a? LogStash::Event }
-        insist { event.get("foo") } == test_event.get("foo")
-        insist { event.get("bar") } == test_event.get("bar")
-      end
+      next LogStash::Codecs::Avro.new(avro_config)
     end
 
-    it "should throw exception if decoding fails" do
-      expect { subject.decode("not avro") { |_| } }.to raise_error NoMethodError
-    end
-  end
-
-  context "#decode with tag_on_failure" do
-    let (:avro_config) { super.merge("tag_on_failure" => true) }
-
-    it "should tag event on failure" do
-      subject.decode("not avro") do |event|
-        insist { event.is_a? LogStash::Event }
-        insist { event.get("tags") } == ["_avroparsefailure"]
-      end
-    end
-  end
-
-  context "#encode" do
-    it "should return avro data from a LogStash::Event" do
-      got_event = false
-      subject.on_event do |event, data|
+    context "#decode" do
+      it "should return an LogStash::Event from avro data" do
         schema = Avro::Schema.parse(avro_config['schema_uri'])
-        datum = StringIO.new(data)
-        decoder = Avro::IO::BinaryDecoder.new(datum)
-        datum_reader = Avro::IO::DatumReader.new(schema)
-        record = datum_reader.read(decoder)
+        dw = Avro::IO::DatumWriter.new(schema)
+        buffer = StringIO.new
+        encoder = Avro::IO::BinaryEncoder.new(buffer)
+        dw.write(test_event.to_hash, encoder)
 
-        insist { record["foo"] } == test_event.get("foo")
-        insist { record["bar"] } == test_event.get("bar")
-        insist { event.is_a? LogStash::Event }
-        got_event = true
+        subject.decode(Base64.strict_encode64(buffer.string)) do |event|
+          insist {event.is_a? LogStash::Event}
+          insist {event.get("foo")} == test_event.get("foo")
+          insist {event.get("bar")} == test_event.get("bar")
+        end
       end
-      subject.encode(test_event)
-      insist { got_event }
+
+      it "should throw exception if decoding fails" do
+        expect {subject.decode("not avro") {|_| }}.to raise_error ArgumentError
+      end
+    end
+
+    context "#decode with tag_on_failure" do
+      let (:avro_config) {super.merge("tag_on_failure" => true)}
+
+      it "should tag event on failure" do
+        subject.decode("not avro") do |event|
+          insist {event.is_a? LogStash::Event}
+          insist {event.get("tags")} == ["_avroparsefailure"]
+        end
+      end
+    end
+
+    context "#encode" do
+      it "should return avro data from a LogStash::Event" do
+        got_event = false
+        subject.on_event do |event, data|
+          schema = Avro::Schema.parse(avro_config['schema_uri'])
+          datum = StringIO.new(Base64.strict_decode64(data))
+          decoder = Avro::IO::BinaryDecoder.new(datum)
+          datum_reader = Avro::IO::DatumReader.new(schema)
+          record = datum_reader.read(decoder)
+
+          insist {record["foo"]} == test_event.get("foo")
+          insist {record["bar"]} == test_event.get("bar")
+          insist {event.is_a? LogStash::Event}
+          got_event = true
+        end
+        subject.encode(test_event)
+        insist {got_event}
+      end
+
+      context "binary data" do
+
+        let (:avro_config) {{ 'schema_uri' => '{"namespace": "com.systems.test.data",
+                      "type": "record",
+                      "name": "TestRecord",
+                      "fields": [
+                        {"name": "name", "type": ["string", "null"]},
+                        {"name": "longitude", "type": ["double", "null"]},
+                        {"name": "latitude", "type": ["double", "null"]}
+                      ]
+                    }' }}
+        let (:test_event) {LogStash::Event.new({ "name" => "foo", "longitude" => 21.01234.to_f, "latitude" => 111.0123.to_f })}
+
+        subject do
+          allow_any_instance_of(LogStash::Codecs::Avro).to \
+      receive(:open_and_read).and_return(avro_config['schema_uri'])
+          next LogStash::Codecs::Avro.new(avro_config)
+        end
+
+        it "should correctly encode binary data" do
+          schema = Avro::Schema.parse(avro_config['schema_uri'])
+          dw = Avro::IO::DatumWriter.new(schema)
+          buffer = StringIO.new
+          encoder = Avro::IO::BinaryEncoder.new(buffer)
+          dw.write(test_event.to_hash, encoder)
+
+          subject.decode(Base64.strict_encode64(buffer.string)) do |event|
+            insist {event.is_a? LogStash::Event}
+            insist {event.get("name")} == test_event.get("name")
+            insist {event.get("longitude")} == test_event.get("longitude")
+            insist {event.get("latitude")} == test_event.get("latitude")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #5 and #12 

Long story short, the problem of using the Avro codec with Kafka is, that the interface or the codec is `String` for the input and output type.

The Ruby implementation of Avro is setup to work with the chars that Ruby strings may contain, but once these strings through Kafka's internal Java/Scala calls:

```java
String.getBytes("UTF-8")
new String(someByteArray, "UTF-8")
```

Bytes may be stripped since whatever Ruby Avro produces isn't necessarily UTF-8.

=> Fixed by wrapping it all in base64 ... not pretty but compatible with Strings in Kafka.
=> I suggest to move this Java as discussed elsewhere next to more than make up for the performance hit we take here.