### PR TITLE
Add `encoding` selector option (base64 or binary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.0
+  - Add `base64_encoding` option to disable the base64 encoding of Avro payload [#38](https://github.com/logstash-plugins/logstash-codec-avro/pull/38)
+
 ## 3.3.1
   - Pin avro gem to 1.10.x, as 1.11+ requires ruby 2.6+ [#37](https://github.com/logstash-plugins/logstash-codec-avro/pull/37)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.0
-  - Add `base64_encoding` option to disable the base64 encoding of Avro payload [#38](https://github.com/logstash-plugins/logstash-codec-avro/pull/38)
+  - Add `base64_encoding` option to disable the base64 encoding of Avro payload [#39](https://github.com/logstash-plugins/logstash-codec-avro/pull/39)
 
 ## 3.3.1
   - Pin avro gem to 1.10.x, as 1.11+ requires ruby 2.6+ [#37](https://github.com/logstash-plugins/logstash-codec-avro/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.4.0
-  - Add `base64_encoding` option to disable the base64 encoding of Avro payload [#39](https://github.com/logstash-plugins/logstash-codec-avro/pull/39)
+  - Add `encoding` option to select the encoding of Avro payload, could be `binary` or `base64` [#39](https://github.com/logstash-plugins/logstash-codec-avro/pull/39)
 
 ## 3.3.1
   - Pin avro gem to 1.10.x, as 1.11+ requires ruby 2.6+ [#37](https://github.com/logstash-plugins/logstash-codec-avro/pull/37)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -106,10 +106,10 @@ Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (E
 * Value can be any of: `binary`, `base64`
 * Default value is `base64`
 
-Select which encoding to use to represent Avro's payload.
-By default, it uses `base64`, however could be customized with `binary` to use the plain binary bytes.
-With `base64` encoding the raw binary bytes are converted to a `base64` encoded string.
+Set encoding for Avro's payload. 
+Use `base64` (default) encoding to convert the raw binary bytes to a `base64` encoded string.
 
+Set this option to `binary` to use the plain binary bytes.
 
 [id="plugins-{type}s-{plugin}-schema_uri"]
 ===== `schema_uri` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -81,6 +81,7 @@ output {
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-base64_encoding>> | <<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_uri>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<boolean,boolean>>|No
@@ -98,6 +99,16 @@ output {
 ** `v1`,`v8`: Elastic Common Schema compliant behavior (`[event][original]` is also added)
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+
+[id="plugins-{type}s-{plugin}-base64_encoding"]
+===== `base64_encoding`
+
+* Value type is <<boolean,boolean>>
+* Default value is `true`
+
+Select whether use or not the base64 encoding.
+When it's `true` and plain message arrives then it's however decoded.
+Raises an error if it's `false` and base64 encodec message arrives.
 
 
 [id="plugins-{type}s-{plugin}-schema_uri"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -81,7 +81,7 @@ output {
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
-| <<plugins-{type}s-{plugin}-base64_encoding>> | <<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-encoding>> | <<string,string>>, one of `["binary", "base64"]`|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-schema_uri>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<boolean,boolean>>|No
@@ -100,15 +100,15 @@ output {
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
-[id="plugins-{type}s-{plugin}-base64_encoding"]
-===== `base64_encoding`
+[id="plugins-{type}s-{plugin}-encoding"]
+===== `encoding`
 
-* Value type is <<boolean,boolean>>
-* Default value is `true`
+* Value can be any of: `binary`, `base64`
+* Default value is `base64`
 
-Select whether use or not the base64 encoding.
-When it's `true` and plain message arrives then it's however decoded.
-Raises an error if it's `false` and base64 encodec message arrives.
+Select which encoding to use to represent Avro's payload.
+By default, it uses `base64`, however could be customized with `binary` to use the plain binary bytes.
+With `base64` encoding the raw binary bytes are converted to a `base64` encoded string.
 
 
 [id="plugins-{type}s-{plugin}-schema_uri"]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -107,9 +107,10 @@ Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (E
 * Default value is `base64`
 
 Set encoding for Avro's payload. 
-Use `base64` (default) encoding to convert the raw binary bytes to a `base64` encoded string.
+Use `base64` (default) to indicate that this codec sends or expects to receive base64-encoded bytes.
 
-Set this option to `binary` to use the plain binary bytes.
+Set this option to `binary` to indicate that this codec sends or expects to receive binary Avro data.
+
 
 [id="plugins-{type}s-{plugin}-schema_uri"]
 ===== `schema_uri` 

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -62,9 +62,9 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   BINARY_ENCODING = "binary"
   BASE64_ENCODING = "base64"
 
-  # Select which encoding to use to represent Avro's payload.
-  # By default, it uses `base64`, however could be customized with `binary` to use the plain binary bytes.
-  # With `base64` encoding the raw binary bytes are converted to a `base64` encoded string.
+  # Set encoding for Avro's payload.
+  #  Use `base64` (default) encoding to convert the raw binary bytes to a `base64` encoded string.
+  #  Set this option to `binary` to use the plain binary bytes.
   config :encoding, :validate => [BINARY_ENCODING, BASE64_ENCODING], :default => BASE64_ENCODING
 
   # schema path to fetch the schema from.

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -59,8 +59,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
-  BINARY_ENCODING = "binary"
-  BASE64_ENCODING = "base64"
+  BINARY_ENCODING = "binary".freeze
+  BASE64_ENCODING = "base64".freeze
 
   # Set encoding for Avro's payload.
   #  Use `base64` (default) encoding to convert the raw binary bytes to a `base64` encoded string.

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -59,6 +59,9 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
+  # make base64 encoding optional
+  config :base64_encoding, :validate => :boolean, :default => true
+
   # schema path to fetch the schema from.
   # This can be a 'http' or 'file' scheme URI
   # example:
@@ -70,9 +73,6 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # tag events with `_avroparsefailure` when decode fails
   config :tag_on_failure, :validate => :boolean, :default => false
 
-  # make base64 encoding optional
-  config :base64_encoding, :validate => :boolean, :default => true
-  
   # Defines a target field for placing decoded fields.
   # If this setting is omitted, data gets stored at the root (top level) of the event.
   #
@@ -95,7 +95,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   public
   def decode(data)
-    if base64_encoding == true
+    if base64_encoding
       datum = StringIO.new(Base64.strict_decode64(data)) rescue StringIO.new(data)
     else
       datum = StringIO.new(data)
@@ -120,7 +120,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     buffer = StringIO.new
     encoder = Avro::IO::BinaryEncoder.new(buffer)
     dw.write(event.to_hash, encoder)
-    if base64_encoding == true
+    if base64_encoding
       @on_event.call(event, Base64.strict_encode64(buffer.string))
     else
       @on_event.call(event, buffer.string)

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.3.1'
+  s.version         = '3.4.0'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Reads serialized Avro records as Logstash events"

--- a/spec/codecs/avro_spec.rb
+++ b/spec/codecs/avro_spec.rb
@@ -55,8 +55,8 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
         end
       end
 
-      context "base64_encoding is false" do
-        let (:avro_config) { super().merge('base64_encoding' => false) }
+      context "with binary encoding" do
+        let (:avro_config) { super().merge('encoding' => 'binary') }
 
         it "should return an LogStash::Event from raw and base64 encoded avro data" do
           schema = Avro::Schema.parse(avro_config['schema_uri'])
@@ -140,8 +140,8 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           insist {got_event}
         end
 
-        context "base64_encoding is false" do
-          let (:avro_config) { super().merge('base64_encoding' => false) }
+        context "with binary encoding" do
+          let (:avro_config) { super().merge('encoding' => 'binary') }
 
           it "should return avro data from a LogStash::Event not base64 encoded" do
             got_event = false


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Add `encoding` option to select the encoding of Avro payload between `base64` (default) and `binary`

## What does this PR do?
Adds `encoding`  set option to choose the encoding of Avro payload.
By default it's set to `base64`.


## Why is it important/What is the impact to the user?

Let the user to decide  whether to use `binary` or `base64` encoding.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] run this gem in Logstash

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- clone this branch and configure `Gemfile`
- execute the pipeline:
```
input {
  generator {
    message => '{"id": "my account", "amount": 5.0}'
    count => 1 
    codec => json
  }
}

output {
  stdout {
    codec => avro {
      schema_uri => "/tmp/avro_schema_payment.asvc"
      base64_encoding => false
    }
  }
}
```
- Avro schema to save in  `/tmp/avro_schema_payment.asvc`
```
{"namespace": "io.confluent.examples.clients.basicavro",
 "type": "record",
 "name": "Payment",
 "fields": [
     {"name": "id", "type": "string"},
     {"name": "amount", "type": "double"}
 ]
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #30

## Use cases
As user I want to receive the binary Avro payload without base64 encoding.

