### PR TITLE
Fix no such file or dir error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.1
+  - Fixes `(Errno::ENOENT) No such file or directory` error [#43](https://github.com/logstash-plugins/logstash-codec-avro/pull/43)
+
 ## 3.4.0
   - Add `encoding` option to select the encoding of Avro payload, could be `binary` or `base64` [#39](https://github.com/logstash-plugins/logstash-codec-avro/pull/39)
 

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -85,7 +85,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   config :target, :validate => :field_reference
 
   def open_and_read(uri_string)
-    open(uri_string).read
+    URI.open(uri_string, &:read)
   end
 
   public

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,14 +1,14 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.4.0'
+  s.version         = '3.4.1'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Reads serialized Avro records as Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
-  s.homepage        = "http://www.elastic.co/guide/en/logstash/current/index.html"
+  s.homepage        = "https://www.elastic.co/logstash"
   s.require_paths   = ["lib"]
 
   # Files


### PR DESCRIPTION
### Description
Logstash 8.10+ versions fail with `(Errno::ENOENT) No such file or directory` error. It is happening after Ruby 2.6 to Ruby 3.1 upgrade through JRuby.
As a solution, it seems there are multiple discussions ([1](https://bugs.ruby-lang.org/issues/15893), [2](https://bugs.ruby-lang.org/issues/19630)) and current solution is to change `open` to `URI.open`

- Closes #42 

### Test
- use `kafka-output` plugin with `avro-codec`
```
input {
  stdin {}
}

output {
    stdout {
        codec => rubydebug
    }
    kafka {
        bootstrap_servers => "192.168.1.66:9092"
        codec => avro {
            schema_uri => "http://127.0.0.1:8081/my-schema"
            #schema_uri => "/static/avro-sample.xml"
            encoding => "binary"
        }
        topic_id => "sample"
    }
}
```
- output logs
```
[2023-10-13T11:01:11,713][DEBUG][logstash.plugins.registry] On demand adding plugin to the registry {:name=>"avro", :type=>"codec", :class=>LogStash::Codecs::Avro}
[2023-10-13T11:01:11,714][DEBUG][logstash.codecs.avro     ] config LogStash::Codecs::Avro/@encoding = "binary"
[2023-10-13T11:01:11,714][DEBUG][logstash.codecs.avro     ] config LogStash::Codecs::Avro/@schema_uri = "/Users/mashhur/Dev/elastic/temp/simple-nodejs/static/avro-sample.xml"
[2023-10-13T11:01:11,715][DEBUG][logstash.codecs.avro     ] config LogStash::Codecs::Avro/@id = "96ef7bd9-34cc-4a71-b184-c6087411fa3c"
[2023-10-13T11:01:11,715][DEBUG][logstash.codecs.avro     ] config LogStash::Codecs::Avro/@enable_metric = true
[2023-10-13T11:01:11,715][DEBUG][logstash.codecs.avro     ] config LogStash::Codecs::Avro/@tag_on_failure = false
```
