### PR TITLE
Add a support for standard SSL configurations, proxy and basic auth configs.

### DIFF
--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -10,7 +10,6 @@ if [[ "$INTEGRATION" != "true" ]]; then
 else
   # Define the Kafka:Confluent version pairs
   VERSIONS=(
-  # "3.9.1:7.4.0"
     "4.1.0:8.0.0"
   )
 

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is intended to be run inside the docker container as the command of the docker-compose.
+
+env
+
+set -ex
+
+if [[ "$INTEGRATION" != "true" ]]; then
+  bundle exec rake test
+else
+  # Define the Kafka:Confluent version pairs
+  VERSIONS=(
+  # "3.9.1:7.4.0"
+    "4.1.0:8.0.0"
+  )
+
+  for pair in "${VERSIONS[@]}"; do
+    KAFKA_VERSION="${pair%%:*}"
+    CONFLUENT_VERSION="${pair##*:}"
+
+    echo "=================================================="
+    echo " Testing with Kafka $KAFKA_VERSION / Confluent $CONFLUENT_VERSION"
+    echo "=================================================="
+
+    export KAFKA_VERSION
+    export CONFLUENT_VERSION
+
+    cd spec/integration && ./kafka_test_setup.sh && cd ../..
+    bundle exec rspec -fd --tag integration
+    cd spec/integration && ./kafka_test_teardown.sh && cd ../..
+  done
+fi
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,12 @@
 import:
 - logstash-plugins/.ci:travis/travis.yml@1.x
+
+jobs:
+  include:
+    - stage: "Integration Tests"
+      env: INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
+    - env: INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=9.current
+    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current
+    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
+    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=9.current
+    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ jobs:
     - stage: "Integration Tests"
       env: INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true LOG_LEVEL=info ELASTIC_STACK_VERSION=9.current
-    - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=7.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=8.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=9.current
     - env: INTEGRATION=true SNAPSHOT=true LOG_LEVEL=info ELASTIC_STACK_VERSION=main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 3.5.0
+  - Add SSL/TLS support for HTTPS schema registry connections
+    - Add `ssl_enabled` option to enable/disable SSL
+    - Add `ssl_certificate` and `ssl_key` options for PEM-based client authentication (unencrypted keys only)
+    - Add `ssl_certificate_authorities` option for PEM-based server certificate validation
+    - Add `ssl_verification_mode` option to control SSL verification (full, none)
+    - Add `ssl_cipher_suites` option to configure cipher suites
+    - Add `ssl_supported_protocols` option to configure TLS protocol versions (TLSv1.1, TLSv1.2, TLSv1.3)
+    - Add `ssl_truststore_path` and `ssl_truststore_password` options for server certificate validation (JKS/PKCS12)
+    - Add `ssl_keystore_path` and `ssl_keystore_password` options for mutual TLS authentication (JKS/PKCS12)
+    - Add `ssl_truststore_type` and `ssl_keystore_type` options (JKS or PKCS12)
+  - Add HTTP proxy support with `proxy` option
+  - Add HTTP basic authentication support with `username` and `password` options
+
 ## 3.4.1
   - Fixes `(Errno::ENOENT) No such file or directory` error [#43](https://github.com/logstash-plugins/logstash-codec-avro/pull/43)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -134,8 +134,8 @@ Set this option to `binary` to indicate that this codec sends or expects to rece
 * Value type is <<password,password>>
 * There is no default value for this setting.
 
-Password for HTTP basic authentication when fetching the schema from a remote server.
-Must be used in combination with the `username` setting.
+Password for HTTP basic authentication when fetching remote schemas.
+Used together with `username`.
 
 [id="plugins-{type}s-{plugin}-proxy"]
 ===== `proxy`
@@ -143,7 +143,7 @@ Must be used in combination with the `username` setting.
 * Value type is <<uri,uri>>
 * There is no default value for this setting.
 
-Proxy server URL for schema registry connections.
+The address of a forward HTTP proxy to use when contacting a remote schema registry.
 
 [id="plugins-{type}s-{plugin}-schema_uri"]
 ===== `schema_uri` 
@@ -174,8 +174,7 @@ tag events with `_avroparsefailure` when decode fails
 * There is no default value for this setting.
 
 Path to PEM encoded certificate file for client authentication (mutual TLS).
-This is an alternative to using <<plugins-{type}s-{plugin}-ssl_keystore_path>>.
-You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_keystore_path>> at the same time.
+You may use this setting or <<plugins-{type}s-{plugin}-ssl_keystore_path>>, but not both simultaneously.
 
 *Example*
 [source,ruby]
@@ -242,8 +241,6 @@ When using HTTPS schema URIs, SSL is automatically enabled.
 The path to the JKS or PKCS12 keystore file for client certificate authentication.
 Use this when the schema registry requires mutual TLS (mTLS) authentication.
 
-This setting is only used when `schema_uri` uses the `https://` scheme.
-
 [id="plugins-{type}s-{plugin}-ssl_keystore_password"]
 ===== `ssl_keystore_password`
 
@@ -280,8 +277,6 @@ When not specified, the JVM defaults are used.
 The path to the JKS or PKCS12 truststore file containing certificates to verify
 the schema registry server's certificate.
 
-This setting is only used when `schema_uri` uses the `https://` scheme.
-
 *Example*
 [source,ruby]
 ----------------------------------
@@ -310,7 +305,7 @@ The password for the truststore file specified in <<plugins-{type}s-{plugin}-ssl
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-The type of the truststore file. Can be either `JKS` or `PKCS12`.
+The format of the truststore file. It must be either `JKS` or `PKCS12`.
 
 [id="plugins-{type}s-{plugin}-ssl_verification_mode"]
 ===== `ssl_verification_mode`
@@ -367,8 +362,8 @@ input {
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-Username for HTTP basic authentication when fetching the schema from a remote server.
-Must be used in combination with the `password` setting.
+Username for HTTP basic authentication when fetching remote schemas.
+Used together with `password`.
 
 *Example*
 [source,ruby]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -83,9 +83,25 @@ output {
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-encoding>> | <<string,string>>, one of `["binary", "base64"]`|No
+| <<plugins-{type}s-{plugin}-password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_uri>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_key>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_path>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_keystore_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_password>> |<<password,password>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_path>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_truststore_type>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-ssl_verification_mode>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-tag_on_failure>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+| <<plugins-{type}s-{plugin}-username>> |<<string,string>>|No
 |=======================================================================
 
 &nbsp;
@@ -112,6 +128,23 @@ Use `base64` (default) to indicate that this codec sends or expects to receive b
 Set this option to `binary` to indicate that this codec sends or expects to receive binary Avro data.
 
 
+[id="plugins-{type}s-{plugin}-password"]
+===== `password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+Password for HTTP basic authentication when fetching the schema from a remote server.
+Must be used in combination with the `username` setting.
+
+[id="plugins-{type}s-{plugin}-proxy"]
+===== `proxy`
+
+* Value type is <<uri,uri>>
+* There is no default value for this setting.
+
+Proxy server URL for schema registry connections.
+
 [id="plugins-{type}s-{plugin}-schema_uri"]
 ===== `schema_uri` 
 
@@ -134,6 +167,175 @@ example:
 
 tag events with `_avroparsefailure` when decode fails
 
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+Path to PEM encoded certificate file for client authentication (mutual TLS).
+This is an alternative to using `ssl_keystore_path`.
+
+*Example*
+[source,ruby]
+----------------------------------
+ssl_certificate => "/path/to/client.crt"
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+Path to PEM encoded CA certificate file(s) for server verification.
+This is an alternative to using `ssl_truststore_path`.
+
+*Example*
+[source,ruby]
+----------------------------------
+ssl_certificate_authorities => "/path/to/ca.crt"
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
+===== `ssl_cipher_suites`
+
+* Value type is <<array,array>>
+* There is no default value for this setting.
+
+The list of cipher suites to use, listed by priorities.
+Supported cipher suites vary depending on which version of Java is used.
+
+[id="plugins-{type}s-{plugin}-ssl_key"]
+===== `ssl_key`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+Path to PEM encoded private key file for client authentication.
+Must be used together with `ssl_certificate`.
+The private key must be unencrypted (passphrase-protected keys are not supported).
+
+*Example*
+[source,ruby]
+----------------------------------
+ssl_key => "/path/to/client.key"
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-ssl_enabled"]
+===== `ssl_enabled`
+
+* Value type is <<boolean,boolean>>
+* There is no default value for this setting.
+
+Enable SSL/TLS secured communication to remote schema registry.
+When using HTTPS schema URIs, SSL is automatically enabled.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_path"]
+===== `ssl_keystore_path`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+The path to the JKS or PKCS12 keystore file for client certificate authentication.
+Use this when the schema registry requires mutual TLS (mTLS) authentication.
+
+This setting is only used when `schema_uri` uses the `https://` scheme.
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_password"]
+===== `ssl_keystore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+The password for the keystore file specified in `ssl_keystore_path`.
+
+
+[id="plugins-{type}s-{plugin}-ssl_keystore_type"]
+===== `ssl_keystore_type`
+
+* Value type is <<string,string>>
+* Default value is `"JKS"`
+
+The type of the keystore file. Can be either `JKS` or `PKCS12`.
+
+[id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
+===== `ssl_supported_protocols`
+
+* Value type is <<array,array>>
+* Default value is `[]` (uses Java defaults)
+* Valid values are: `TLSv1.1`, `TLSv1.2`, `TLSv1.3`
+
+List of allowed SSL/TLS protocol versions.
+When not specified, the JVM defaults are used.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_path"]
+===== `ssl_truststore_path`
+
+* Value type is <<path,path>>
+* There is no default value for this setting.
+
+The path to the JKS or PKCS12 truststore file containing certificates to verify
+the schema registry server's certificate.
+
+This setting is only used when `schema_uri` uses the `https://` scheme.
+
+*Example*
+[source,ruby]
+----------------------------------
+input {
+  kafka {
+    codec => avro {
+        schema_uri => "https://schema-registry.example.com:8081/schemas/ids/1"
+        ssl_truststore_path => "/path/to/truststore.jks"
+        ssl_truststore_password => "${TRUSTSTORE_PASSWORD}"
+    }
+  }
+}
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_password"]
+===== `ssl_truststore_password`
+
+* Value type is <<password,password>>
+* There is no default value for this setting.
+
+The password for the truststore file specified in `ssl_truststore_path`.
+
+[id="plugins-{type}s-{plugin}-ssl_truststore_type"]
+===== `ssl_truststore_type`
+
+* Value type is <<string,string>>
+* Default value is `"JKS"`
+
+The type of the truststore file. Can be either `JKS` or `PKCS12`.
+
+[id="plugins-{type}s-{plugin}-ssl_verification_mode"]
+===== `ssl_verification_mode`
+
+* Value type is <<string,string>>
+* Default value is `"full"`
+* Valid options are: `full`, `none`
+
+Options to verify the server's certificate:
+
+* `full`: Validates that the provided certificate has an issue date that's within the not_before and not_after dates; chains to a trusted Certificate Authority (CA); has a hostname or IP address that matches the names within the certificate. (recommended)
+* `none`: Performs no certificate validation. **Warning:** Disabling this severely compromises security (https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)
+
+*Example*
+[source,ruby]
+----------------------------------
+input {
+  kafka {
+    codec => avro {
+        schema_uri => "https://schema-registry.example.com:8081/schemas/ids/1"
+        ssl_certificate_authorities => "/path/to/ca.crt"
+        ssl_verification_mode => "full"
+    }
+  }
+}
+----------------------------------
+
 [id="plugins-{type}s-{plugin}-target"]
 ===== `target`
 
@@ -152,6 +354,29 @@ input {
     codec => avro {
         schema_uri => "/tmp/schema.avsc"
         target => "[document]"
+    }
+  }
+}
+----------------------------------
+
+[id="plugins-{type}s-{plugin}-username"]
+===== `username`
+
+* Value type is <<string,string>>
+* There is no default value for this setting.
+
+Username for HTTP basic authentication when fetching the schema from a remote server.
+Must be used in combination with the `password` setting.
+
+*Example*
+[source,ruby]
+----------------------------------
+input {
+  kafka {
+    codec => avro {
+        schema_uri => "https://schema-registry.example.com:8081/schemas/ids/1"
+        username => "registry_user"
+        password => "${REGISTRY_PASSWORD}"
     }
   }
 }

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -190,7 +190,7 @@ ssl_certificate => "/path/to/client.crt"
 
 Path to PEM encoded CA certificate file(s) for server verification.
 This is an alternative to using <<plugins-{type}s-{plugin}-ssl_truststore_path>>.
-You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_truststore_path>> at the same time.
+You may use this setting or <<plugins-{type}s-{plugin}-ssl_truststore_path>>, but not both simultaneously.
 
 *Example*
 [source,ruby]
@@ -256,7 +256,7 @@ The password for the keystore file specified in <<plugins-{type}s-{plugin}-ssl_k
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-The type of the keystore file. Can be either `JKS` or `PKCS12`.
+The format of the keystore file. It must be either `jks` or `pkcs12`.
 
 [id="plugins-{type}s-{plugin}-ssl_supported_protocols"]
 ===== `ssl_supported_protocols`
@@ -305,7 +305,7 @@ The password for the truststore file specified in <<plugins-{type}s-{plugin}-ssl
 * Value type is <<string,string>>
 * There is no default value for this setting.
 
-The format of the truststore file. It must be either `JKS` or `PKCS12`.
+The format of the truststore file. It must be either `jks` or `pkcs12`.
 
 [id="plugins-{type}s-{plugin}-ssl_verification_mode"]
 ===== `ssl_verification_mode`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -87,7 +87,7 @@ output {
 | <<plugins-{type}s-{plugin}-proxy>> |<<uri,uri>>|No
 | <<plugins-{type}s-{plugin}-schema_uri>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-ssl_certificate>> |<<path,path>>|No
-| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<path,path>>|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |list of <<path,path>>|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_enabled>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |<<path,path>>|No
@@ -174,7 +174,8 @@ tag events with `_avroparsefailure` when decode fails
 * There is no default value for this setting.
 
 Path to PEM encoded certificate file for client authentication (mutual TLS).
-This is an alternative to using `ssl_keystore_path`.
+This is an alternative to using <<plugins-{type}s-{plugin}-ssl_keystore_path>>.
+You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_keystore_path>> at the same time.
 
 *Example*
 [source,ruby]
@@ -185,16 +186,17 @@ ssl_certificate => "/path/to/client.crt"
 [id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
 ===== `ssl_certificate_authorities`
 
-* Value type is <<path,path>>
+* Value type is a list of <<path,path>>
 * There is no default value for this setting.
 
 Path to PEM encoded CA certificate file(s) for server verification.
-This is an alternative to using `ssl_truststore_path`.
+This is an alternative to using <<plugins-{type}s-{plugin}-ssl_truststore_path>>.
+You cannot use this setting and <<plugins-{type}s-{plugin}-ssl_truststore_path>> at the same time.
 
 *Example*
 [source,ruby]
 ----------------------------------
-ssl_certificate_authorities => "/path/to/ca.crt"
+ssl_certificate_authorities => ["/path/to/ca.crt"]
 ----------------------------------
 
 [id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
@@ -213,7 +215,7 @@ Supported cipher suites vary depending on which version of Java is used.
 * There is no default value for this setting.
 
 Path to PEM encoded private key file for client authentication.
-Must be used together with `ssl_certificate`.
+Must be used together with <<plugins-{type}s-{plugin}-ssl_certificate>>.
 The private key must be unencrypted (passphrase-protected keys are not supported).
 
 *Example*
@@ -248,14 +250,14 @@ This setting is only used when `schema_uri` uses the `https://` scheme.
 * Value type is <<password,password>>
 * There is no default value for this setting.
 
-The password for the keystore file specified in `ssl_keystore_path`.
+The password for the keystore file specified in <<plugins-{type}s-{plugin}-ssl_keystore_path>>.
 
 
 [id="plugins-{type}s-{plugin}-ssl_keystore_type"]
 ===== `ssl_keystore_type`
 
 * Value type is <<string,string>>
-* Default value is `"JKS"`
+* There is no default value for this setting.
 
 The type of the keystore file. Can be either `JKS` or `PKCS12`.
 
@@ -300,13 +302,13 @@ input {
 * Value type is <<password,password>>
 * There is no default value for this setting.
 
-The password for the truststore file specified in `ssl_truststore_path`.
+The password for the truststore file specified in <<plugins-{type}s-{plugin}-ssl_truststore_path>>.
 
 [id="plugins-{type}s-{plugin}-ssl_truststore_type"]
 ===== `ssl_truststore_type`
 
 * Value type is <<string,string>>
-* Default value is `"JKS"`
+* There is no default value for this setting.
 
 The type of the truststore file. Can be either `JKS` or `PKCS12`.
 
@@ -329,7 +331,7 @@ input {
   kafka {
     codec => avro {
         schema_uri => "https://schema-registry.example.com:8081/schemas/ids/1"
-        ssl_certificate_authorities => "/path/to/ca.crt"
+        ssl_certificate_authorities => ["/path/to/ca.crt"]
         ssl_verification_mode => "full"
     }
   }

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -190,13 +190,13 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     https_connection = uri_string.start_with?('https://')
 
     if http_connection
-      ssl_config_provided = original_params.keys.select {|k| k.start_with?("ssl_") && k != "ssl_enabled" }
+      ssl_config_provided = original_params.keys.select {|k| k.start_with?("ssl_") }
       if ssl_config_provided.any?
         raise_config_error! "When SSL is disabled, the following provided parameters are not allowed: #{ssl_config_provided}"
       end
 
       credentials_configured = @username && @password
-      @logger.warn("Credentials are being sent over unencrypted HTTP. This may bring security risk.") if credentials_configured && http_connection
+      @logger.warn("Credentials are being sent over unencrypted HTTP. This may bring security risk.") if credentials_configured
       fetch_remote_schema(uri_string)
     elsif https_connection
       validate_ssl_settings!
@@ -208,6 +208,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   end
 
   def fetch_remote_schema(uri_string)
+    client = nil
     client_options = {}
 
     if @proxy && !@proxy.empty?
@@ -232,18 +233,16 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     body = response.body
     # Response may contain schema metadata, schema field is what we need
     # Example response: {"subject":"test-no-auth-1763597024","version":1,"id":1,"guid":"5c6c5f26-e876-e5ab-02b0-8d9bebbc90d7","schemaType":"AVRO","schema":"{"type":"record","name":"TestRecord","namespace":"com.example","fields":[{"name":"message","type":"string"},{"name":"timestamp","type":"long"}]}","ts":1763597024561,"deleted":false}
-    begin
-      parsed = JSON.parse(body)
-      if parsed.is_a?(Hash) && parsed.has_key?('schema')
-        parsed['schema']
-      else
-        # fallback to use the response as it is
-        body
-      end
-    rescue JSON::ParserError
-      # Not JSON, return as-is (probably a direct schema)
+    parsed = JSON.parse(body)
+    if parsed.is_a?(Hash) && parsed.has_key?('schema')
+      parsed['schema']
+    else
+      # fallback to use the response as it is
       body
     end
+  rescue JSON::ParserError
+    # Not JSON, return as-is (probably a direct schema)
+    body
   ensure
     client.close if client
   end
@@ -263,6 +262,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   def validate_ssl_settings!
     @ssl_enabled = true if @ssl_enabled.nil?
+    raise_config_error! "Secured #{@schema_uri} connection requires `ssl_enabled => true`. " unless @ssl_enabled
     @ssl_verification_mode = "full".freeze if @ssl_verification_mode.nil?
 
     # optional: presenting our identity
@@ -270,8 +270,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     raise_config_error! "`ssl_certificate` requires `ssl_key`" if @ssl_certificate && !@ssl_key
     ensure_readable_and_non_writable! "ssl_certificate", @ssl_certificate if @ssl_certificate
 
-     raise_config_error! "`ssl_key` is not allowed unless `ssl_certificate` is specified" if @ssl_key && !@ssl_certificate
-     ensure_readable_and_non_writable! "ssl_key", @ssl_key if @ssl_key
+    raise_config_error! "`ssl_key` is not allowed unless `ssl_certificate` is specified" if @ssl_key && !@ssl_certificate
+    ensure_readable_and_non_writable! "ssl_key", @ssl_key if @ssl_key
 
     raise_config_error! "`ssl_keystore_path` requires `ssl_keystore_password`" if @ssl_keystore_path && !@ssl_keystore_password
     raise_config_error! "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified" if @ssl_keystore_password && !@ssl_keystore_path

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -4,6 +4,7 @@ require "manticore"
 require "avro"
 require "base64"
 require "json"
+require "stud/try"
 require "logstash/codecs/base"
 require "logstash/event"
 require "logstash/timestamp"
@@ -224,13 +225,20 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     end
 
     client = Manticore::Client.new(client_options)
-    response = client.get(uri_string).call
 
-    unless response.code == 200
-      raise "HTTP request failed: #{response.code} #{response.message}"
+    body = Stud.try(3.times, [Manticore::SocketException, Manticore::Timeout, StandardError]) do
+      @logger.debug("Fetching schema from #{uri_string}") if @logger
+      response = client.get(uri_string).call
+
+      unless response.code == 200
+        error_msg = "HTTP request failed: #{response.code} #{response.message}"
+        @logger.warn(error_msg) if @logger
+        raise error_msg
+      end
+
+      response.body
     end
 
-    body = response.body
     # Response may contain schema metadata, schema field is what we need
     # Example response: {"subject":"test-no-auth-1763597024","version":1,"id":1,"guid":"5c6c5f26-e876-e5ab-02b0-8d9bebbc90d7","schemaType":"AVRO","schema":"{"type":"record","name":"TestRecord","namespace":"com.example","fields":[{"name":"message","type":"string"},{"name":"timestamp","type":"long"}]}","ts":1763597024561,"deleted":false}
     parsed = JSON.parse(body)

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -256,9 +256,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     raise LogStash::ConfigurationError, "`username` requires `password`" if @username && !@password
     raise LogStash::ConfigurationError, "`password` is not allowed unless `username` is specified" if !@username && @password
 
-    if @username && @password
-      raise LogStash::ConfigurationError, "Empty `username` or `password` is not allowed" if @username.empty? || @password.value.empty?
-    end
+    raise LogStash::ConfigurationError, "Empty `username` or `password` is not allowed" if @username.empty? || @password.value.empty?
 
     {:user => @username, :password => @password.value}
   end

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -191,7 +191,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     https_connection = uri_string.start_with?('https://')
 
     if http_connection
-      ssl_config_provided = original_params.keys.select {|k| k.start_with?("ssl_") }
+      ssl_config_provided = original_params.keys.select {|k| k.start_with?("ssl_") && k != "ssl_enabled" }
       if ssl_config_provided.any?
         raise_config_error! "When SSL is disabled, the following provided parameters are not allowed: #{ssl_config_provided}"
       end

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "open-uri"
+require "manticore"
 require "avro"
 require "base64"
 require "logstash/codecs/base"
@@ -84,9 +85,59 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # NOTE: the target is only relevant while decoding data into a new event.
   config :target, :validate => :field_reference
 
-  def open_and_read(uri_string)
-    URI.open(uri_string, &:read)
-  end
+  # Proxy server URL for schema registry connections
+  config :proxy, :validate => :uri
+
+  # Username for HTTP basic authentication
+  config :username, :validate => :string
+
+  # Password for HTTP basic authentication
+  config :password, :validate => :password
+
+  # Enable SSL/TLS secured communication to remote schema registry
+  config :ssl_enabled, :validate => :boolean
+
+  # PEM-based SSL configuration (alternative to keystore/truststore)
+  # Path to PEM encoded certificate file for client authentication
+  config :ssl_certificate, :validate => :path
+
+  # Path to PEM encoded private key file for client authentication
+  config :ssl_key, :validate => :path
+
+  # Path to PEM encoded CA certificate file(s) for server verification
+  # Can be a single file or directory containing multiple CA certificates
+  config :ssl_certificate_authorities, :validate => :path
+
+  # Options to verify the server's certificate.
+  # "full": validates that the provided certificate has an issue date that’s within the not_before and not_after dates;
+  # chains to a trusted Certificate Authority (CA); has a hostname or IP address that matches the names within the certificate.
+  # "none": performs no certificate validation. Disabling this severely compromises security (https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)
+  config :ssl_verification_mode, :validate => %w[full none], :default => 'full'
+
+  # The keystore path
+  config :ssl_keystore_path, :validate => :path
+
+  # The keystore password
+  config :ssl_keystore_password, :validate => :password
+
+  # Keystore type (JKS or PKCS12). Defaults to JKS.
+  config :ssl_keystore_type, :validate => %w[JKS PKCS12], :default => "JKS"
+
+  # The truststore path
+  config :ssl_truststore_path, :validate => :path
+
+  # The truststore password
+  config :ssl_truststore_password, :validate => :password
+
+  # Truststore type (JKS or PKCS12). Defaults to JKS.
+  config :ssl_truststore_type, :validate => %w[JKS PKCS12], :default => "JKS"
+
+  # The list of cipher suites to use, listed by priorities.
+  # Supported cipher suites vary depending on which version of Java is used.
+  config :ssl_cipher_suites, :validate => :string, :list => true
+
+  # SSL supported protocols
+  config :ssl_supported_protocols, :validate => %w[TLSv1.1 TLSv1.2 TLSv1.3], :default => [], :list => true
 
   public
   def initialize(*params)
@@ -95,7 +146,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   end
 
   def register
-    @schema = Avro::Schema.parse(open_and_read(schema_uri))
+    @schema = Avro::Schema.parse(fetch_schema(schema_uri))
   end
 
   public
@@ -130,5 +181,150 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     else
       @on_event.call(event, buffer.string)
     end  
+  end
+
+  private
+  def fetch_schema(uri_string)
+    http_connection = uri_string.start_with?('http://')
+    https_connection = uri_string.start_with?('https://')
+
+    if http_connection
+      ssl_config_provided = original_params.keys.select {|k| k.start_with?("ssl_") && k != "ssl_enabled" }
+      if ssl_config_provided.any?
+        raise_config_error! "When SSL is disabled, the following provided parameters are not allowed: #{ssl_config_provided}"
+      end
+
+      credentials_configured = @username && @password
+      @logger.warn("Credentials are being sent over unencrypted HTTP. This may bring security risk.") if credentials_configured && http_connection
+      fetch_remote_schema(uri_string)
+    elsif https_connection
+      validate_ssl_settings!
+      fetch_remote_schema(uri_string)
+    else
+      # local schema
+      URI.open(uri_string, &:read)
+    end
+  end
+
+  def fetch_remote_schema(uri_string)
+    client_options = {}
+
+    unless @proxy&.empty?
+      client_options[:proxy] = @proxy.to_s
+    end
+
+    basic_auth_options = build_basic_auth
+    client_options[:auth] = basic_auth_options unless basic_auth_options.empty?
+
+    if @ssl_enabled
+      ssl_options = build_ssl_options
+      client_options[:ssl] = ssl_options unless ssl_options.empty?
+    end
+
+    client = Manticore::Client.new(client_options)
+    response = client.get(uri_string).call
+
+    unless response.code == 200
+      raise "HTTP request failed: #{response.code} #{response.message}"
+    end
+
+    response.body
+  ensure
+    client.close if client
+  end
+
+  def build_basic_auth
+    if !@username && !@password
+      return {}
+    end
+
+    raise LogStash::ConfigurationError, "`username` requires `password`" if @username && !@password
+    raise LogStash::ConfigurationError, "`password` is not allowed unless `username` is specified" if !@username && @password
+
+    if @username && @password
+      raise LogStash::ConfigurationError, "Empty `username` or `password` is not allowed" if @username.empty? || @password.value.empty?
+    end
+
+    {:user => @username, :password => @password.value}
+  end
+
+  def validate_ssl_settings!
+    @ssl_enabled = true if @ssl_enabled.nil?
+    @ssl_verification_mode = "full".freeze if @ssl_verification_mode.nil?
+
+    # optional: presenting our identity
+    raise_config_error! "`ssl_certificate` and `ssl_keystore_path` cannot be used together." if @ssl_certificate && @ssl_keystore_path
+    raise_config_error! "`ssl_certificate` requires `ssl_key`" if @ssl_certificate && !@ssl_key
+    ensure_readable_and_non_writable! "ssl_certificate", @ssl_certificate if @ssl_certificate
+
+     raise_config_error! "`ssl_key` is not allowed unless `ssl_certificate` is specified" if @ssl_key && !@ssl_certificate
+     ensure_readable_and_non_writable! "ssl_key", @ssl_key if @ssl_key
+
+    raise_config_error! "`ssl_keystore_path` requires `ssl_keystore_password`" if @ssl_keystore_path && !@ssl_keystore_password
+    raise_config_error! "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified" if @ssl_keystore_password && !@ssl_keystore_path
+    raise_config_error! "`ssl_keystore_password` cannot be empty" if @ssl_keystore_password && @ssl_keystore_password.value.empty?
+    raise_config_error! "`ssl_keystore_type` is not allowed unless `ssl_keystore_path` is specified" if @ssl_keystore_type && !@ssl_keystore_path
+
+    ensure_readable_and_non_writable! "ssl_keystore_path", @ssl_keystore_path if @ssl_keystore_path
+
+    # establishing trust of the server we connect to
+    # system-provided trust requires verification mode enabled
+    if @ssl_verification_mode == "none"
+      raise_config_error! "`ssl_truststore_path` requires `ssl_verification_mode` to be either `full`" if @ssl_truststore_path
+      raise_config_error! "`ssl_truststore_password` requires `ssl_truststore_path` and `ssl_verification_mode => 'full'`" if @ssl_truststore_password
+      raise_config_error! "`ssl_certificate_authorities` requires `ssl_verification_mode` to be `full`" if @ssl_certificate_authorities
+    end
+
+    raise_config_error! "`ssl_truststore_path` and `ssl_certificate_authorities` cannot be used together." if @ssl_truststore_path && @ssl_certificate_authorities
+    raise_config_error! "`ssl_truststore_path` requires `ssl_truststore_password`" if @ssl_truststore_path && !@ssl_truststore_password
+    ensure_readable_and_non_writable! "ssl_truststore_path", @ssl_truststore_path if @ssl_truststore_path
+
+    raise_config_error! "`ssl_truststore_password` is not allowed unless `ssl_truststore_path` is specified" if !@ssl_truststore_path && @ssl_truststore_password
+    raise_config_error! "`ssl_truststore_password` cannot be empty" if @ssl_truststore_password && @ssl_truststore_password.value.empty?
+
+    if !@ssl_truststore_path && @ssl_certificate_authorities&.empty?
+      raise_config_error! "`ssl_certificate_authorities` cannot be empty"
+    end
+
+    raise_config_error! "Multiple values on `ssl_certificate_authorities` are not supported by this plugin" if @ssl_certificate_authorities.size > 1
+    ensure_readable_and_non_writable! "ssl_certificate_authorities", @ssl_certificate_authorities&.first
+  end
+
+  def build_ssl_options
+    ssl_options = {}
+
+    ssl_options[:client_cert] = @ssl_certificate if @ssl_certificate
+    ssl_options[:client_key] = @ssl_key if @ssl_key
+
+    ssl_options[:ca_file] = @ssl_certificate_authorities&.first if @ssl_certificate_authorities
+
+    ssl_options[:cipher_suites] = @ssl_cipher_suites if @ssl_cipher_suites
+
+    ssl_options[:verify] = :default if @ssl_verification_mode == 'full'
+    ssl_options[:verify] = :disable if @ssl_verification_mode == 'none'
+
+    ssl_options[:keystore] = @ssl_keystore_path if @ssl_keystore_path
+    ssl_options[:keystore_password] = @ssl_keystore_password&.value if @ssl_keystore_path && @ssl_keystore_password
+    ssl_options[:keystore_type] = @ssl_keystore_type.downcase if @ssl_keystore_path && @ssl_keystore_type
+
+    ssl_options[:truststore] = @ssl_truststore_path if @ssl_truststore_path
+    ssl_options[:truststore_password] = @ssl_truststore_password&.value if @ssl_truststore_path && @ssl_truststore_password
+    ssl_options[:truststore_type] = @ssl_truststore_type.downcase if @ssl_truststore_path && @ssl_truststore_type
+
+    ssl_options[:protocols] = @ssl_supported_protocols if @ssl_supported_protocols && @ssl_supported_protocols&.any?
+
+    ssl_options
+  end
+
+  ##
+  # @param message [String]
+  # @raise [LogStash::ConfigurationError]
+  def raise_config_error!(message)
+    raise LogStash::ConfigurationError, message
+  end
+
+  def ensure_readable_and_non_writable!(name, path)
+    raise_config_error! "Specified #{name} #{path} path must be readable." unless File.readable?(path)
+    raise_config_error! "Specified #{name} #{path} path must not be writable." if File.writable?(path)
   end
 end

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -4,7 +4,6 @@ require "manticore"
 require "avro"
 require "base64"
 require "json"
-require "stud/try"
 require "logstash/codecs/base"
 require "logstash/event"
 require "logstash/timestamp"
@@ -114,7 +113,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # "full": validates that the provided certificate has an issue date that’s within the not_before and not_after dates;
   # chains to a trusted Certificate Authority (CA); has a hostname or IP address that matches the names within the certificate.
   # "none": performs no certificate validation. Disabling this severely compromises security (https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)
-  config :ssl_verification_mode, :validate => %w[full none], :default => 'full'
+  config :ssl_verification_mode, :validate => %w[full none]
 
   # The keystore path
   config :ssl_keystore_path, :validate => :path
@@ -139,7 +138,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   config :ssl_cipher_suites, :validate => :string, :list => true
 
   # SSL supported protocols
-  config :ssl_supported_protocols, :validate => %w[TLSv1.1 TLSv1.2 TLSv1.3], :default => [], :list => true
+  config :ssl_supported_protocols, :validate => %w[TLSv1.1 TLSv1.2 TLSv1.3], :list => true
 
   public
   def initialize(*params)
@@ -182,7 +181,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
       @on_event.call(event, Base64.strict_encode64(buffer.string))
     else
       @on_event.call(event, buffer.string)
-    end  
+    end
   end
 
   private
@@ -226,17 +225,36 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
     client = Manticore::Client.new(client_options)
 
-    body = Stud.try(3.times, [Manticore::SocketException, Manticore::Timeout, StandardError]) do
-      @logger.debug("Fetching schema from #{uri_string}")
-      response = client.get(uri_string).call
+    @logger.debug("Fetching schema from #{uri_string}")
 
+    max_retries = 3
+    retry_count = 0
+    body = nil
+
+    begin
+      response = client.get(uri_string).call
+      
       unless response.code == 200
         error_msg = "Failed to fetch schema from #{uri_string}: #{response.code} - #{response.message}"
-        @logger.warn(error_msg)
-        raise error_msg
+        @logger.error(error_msg)
+        raise StandardError, error_msg
       end
-
-      response.body
+      body = response.body
+    rescue Manticore::ManticoreException => e
+      retry_count += 1
+      if retry_count <= max_retries
+        backoff_time = 2 ** (retry_count - 1)  # Exponential backoff: 1s, 2s, 4s
+        @logger.warn("Attempt #{retry_count}/#{max_retries} failed for #{uri_string}: #{e.class} - #{e.message}. Retrying in #{backoff_time}s...")
+        sleep(backoff_time)
+        retry
+      else
+        @logger.error("Failed to fetch schema from #{uri_string} after #{max_retries} attempts: #{e.class} - #{e.message}")
+        raise
+      end
+    rescue StandardError => e
+      # Don't retry HTTP errors (401, 404, etc.) or other non-transient errors
+      @logger.error("Failed to fetch schema from #{uri_string}: #{e.class} - #{e.message}")
+      raise
     end
 
     # Response may contain schema metadata, schema field is what we need

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -3,6 +3,7 @@ require "open-uri"
 require "manticore"
 require "avro"
 require "base64"
+require "json"
 require "logstash/codecs/base"
 require "logstash/event"
 require "logstash/timestamp"
@@ -209,7 +210,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   def fetch_remote_schema(uri_string)
     client_options = {}
 
-    unless @proxy&.empty?
+    if @proxy && !@proxy.empty?
       client_options[:proxy] = @proxy.to_s
     end
 
@@ -228,7 +229,21 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
       raise "HTTP request failed: #{response.code} #{response.message}"
     end
 
-    response.body
+    body = response.body
+    # Response may contain schema metadata, schema field is what we need
+    # Example response: {"subject":"test-no-auth-1763597024","version":1,"id":1,"guid":"5c6c5f26-e876-e5ab-02b0-8d9bebbc90d7","schemaType":"AVRO","schema":"{"type":"record","name":"TestRecord","namespace":"com.example","fields":[{"name":"message","type":"string"},{"name":"timestamp","type":"long"}]}","ts":1763597024561,"deleted":false}
+    begin
+      parsed = JSON.parse(body)
+      if parsed.is_a?(Hash) && parsed.has_key?('schema')
+        parsed['schema']
+      else
+        # fallback to use the response as it is
+        body
+      end
+    rescue JSON::ParserError
+      # Not JSON, return as-is (probably a direct schema)
+      body
+    end
   ensure
     client.close if client
   end

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -301,8 +301,10 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
       raise_config_error! "`ssl_certificate_authorities` cannot be empty"
     end
 
-    raise_config_error! "Multiple values on `ssl_certificate_authorities` are not supported by this plugin" if @ssl_certificate_authorities && @ssl_certificate_authorities&.size > 1
-    ensure_readable_and_non_writable! "ssl_certificate_authorities", @ssl_certificate_authorities&.first
+    if @ssl_certificate_authorities && !@ssl_certificate_authorities.empty?
+      raise_config_error! "Multiple values on `ssl_certificate_authorities` are not supported by this plugin" if @ssl_certificate_authorities.size > 1
+      ensure_readable_and_non_writable! "ssl_certificate_authorities", @ssl_certificate_authorities.first
+    end
   end
 
   def build_ssl_options

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -122,8 +122,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # The keystore password
   config :ssl_keystore_password, :validate => :password
 
-  # Keystore type (JKS or PKCS12)
-  config :ssl_keystore_type, :validate => %w[JKS PKCS12]
+  # Keystore type (jks or pkcs12)
+  config :ssl_keystore_type, :validate => %w[pkcs12 jks]
 
   # The truststore path
   config :ssl_truststore_path, :validate => :path
@@ -131,8 +131,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # The truststore password
   config :ssl_truststore_password, :validate => :password
 
-  # Truststore type (JKS or PKCS12)
-  config :ssl_truststore_type, :validate => %w[JKS PKCS12]
+  # Truststore type (jks or pkcs12)
+  config :ssl_truststore_type, :validate => %w[jks pkcs12]
 
   # The list of cipher suites to use, listed by priorities.
   # Supported cipher suites vary depending on which version of Java is used.
@@ -227,12 +227,12 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     client = Manticore::Client.new(client_options)
 
     body = Stud.try(3.times, [Manticore::SocketException, Manticore::Timeout, StandardError]) do
-      @logger.debug("Fetching schema from #{uri_string}") if @logger
+      @logger.debug("Fetching schema from #{uri_string}")
       response = client.get(uri_string).call
 
       unless response.code == 200
-        error_msg = "HTTP request failed: #{response.code} #{response.message}"
-        @logger.warn(error_msg) if @logger
+        error_msg = "Failed to fetch schema from #{uri_string}: #{response.code} - #{response.message}"
+        @logger.warn(error_msg)
         raise error_msg
       end
 

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -106,7 +106,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
   # Path to PEM encoded CA certificate file(s) for server verification
   # Can be a single file or directory containing multiple CA certificates
-  config :ssl_certificate_authorities, :validate => :path
+  config :ssl_certificate_authorities, :validate => :path, :list => true
 
   # Options to verify the server's certificate.
   # "full": validates that the provided certificate has an issue date that’s within the not_before and not_after dates;
@@ -120,8 +120,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # The keystore password
   config :ssl_keystore_password, :validate => :password
 
-  # Keystore type (JKS or PKCS12). Defaults to JKS.
-  config :ssl_keystore_type, :validate => %w[JKS PKCS12], :default => "JKS"
+  # Keystore type (JKS or PKCS12)
+  config :ssl_keystore_type, :validate => %w[JKS PKCS12]
 
   # The truststore path
   config :ssl_truststore_path, :validate => :path
@@ -129,8 +129,8 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   # The truststore password
   config :ssl_truststore_password, :validate => :password
 
-  # Truststore type (JKS or PKCS12). Defaults to JKS.
-  config :ssl_truststore_type, :validate => %w[JKS PKCS12], :default => "JKS"
+  # Truststore type (JKS or PKCS12)
+  config :ssl_truststore_type, :validate => %w[JKS PKCS12]
 
   # The list of cipher suites to use, listed by priorities.
   # Supported cipher suites vary depending on which version of Java is used.
@@ -270,7 +270,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     # establishing trust of the server we connect to
     # system-provided trust requires verification mode enabled
     if @ssl_verification_mode == "none"
-      raise_config_error! "`ssl_truststore_path` requires `ssl_verification_mode` to be either `full`" if @ssl_truststore_path
+      raise_config_error! "`ssl_truststore_path` requires `ssl_verification_mode` to be `full`" if @ssl_truststore_path
       raise_config_error! "`ssl_truststore_password` requires `ssl_truststore_path` and `ssl_verification_mode => 'full'`" if @ssl_truststore_password
       raise_config_error! "`ssl_certificate_authorities` requires `ssl_verification_mode` to be `full`" if @ssl_certificate_authorities
     end
@@ -286,7 +286,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
       raise_config_error! "`ssl_certificate_authorities` cannot be empty"
     end
 
-    raise_config_error! "Multiple values on `ssl_certificate_authorities` are not supported by this plugin" if @ssl_certificate_authorities.size > 1
+    raise_config_error! "Multiple values on `ssl_certificate_authorities` are not supported by this plugin" if @ssl_certificate_authorities && @ssl_certificate_authorities&.size > 1
     ensure_readable_and_non_writable! "ssl_certificate_authorities", @ssl_certificate_authorities&.first
   end
 

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -52,6 +52,17 @@ require 'logstash/plugin_mixins/event_support/event_factory_adapter'
 # }
 # ----------------------------------
 class LogStash::Codecs::Avro < LogStash::Codecs::Base
+  class BadResponseCodeError < LogStash::Error
+    attr_reader :code, :message, :uri
+
+    def initialize(code, message, uri)
+      @code = code
+      @message = message
+      @uri = uri
+      super("HTTP #{code}: #{message} (#{uri})")
+    end
+  end
+
   config_name "avro"
 
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
@@ -233,14 +244,28 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
     begin
       response = client.get(uri_string).call
-      
+
       unless response.code == 200
-        error_msg = "Failed to fetch schema from #{uri_string}: #{response.code} - #{response.message}"
-        @logger.error(error_msg)
-        raise StandardError, error_msg
+        @logger.error("Failed to fetch schema from #{uri_string}: #{response.code} - #{response.message}")
+        raise BadResponseCodeError.new(response.code, response.message, uri_string)
       end
+
       body = response.body
-    rescue Manticore::ManticoreException => e
+
+      # Parse and extract schema
+      parsed = JSON.parse(body)
+      return parsed.is_a?(Hash) && parsed.has_key?('schema') ? parsed['schema'] : body
+
+    rescue JSON::ParserError
+      return body
+    rescue Manticore::ManticoreException, BadResponseCodeError => e
+      # 4xx don't retry
+      if e.is_a?(BadResponseCodeError) && e.code >= 400 && e.code < 500
+        @logger.error("Failed to fetch schema from #{uri_string}: #{e.code} - #{e.message}")
+        raise
+      end
+
+      # retry block
       retry_count += 1
       if retry_count <= max_retries
         backoff_time = 2 ** (retry_count - 1)  # Exponential backoff: 1s, 2s, 4s
@@ -248,27 +273,10 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
         sleep(backoff_time)
         retry
       else
-        @logger.error("Failed to fetch schema from #{uri_string} after #{max_retries} attempts: #{e.class} - #{e.message}")
+        @logger.error("Failed to fetch schema from #{uri_string} after #{max_retries + 1} attempts: #{e.class} - #{e.message}")
         raise
       end
-    rescue StandardError => e
-      # Don't retry HTTP errors (401, 404, etc.) or other non-transient errors
-      @logger.error("Failed to fetch schema from #{uri_string}: #{e.class} - #{e.message}")
-      raise
     end
-
-    # Response may contain schema metadata, schema field is what we need
-    # Example response: {"subject":"test-no-auth-1763597024","version":1,"id":1,"guid":"5c6c5f26-e876-e5ab-02b0-8d9bebbc90d7","schemaType":"AVRO","schema":"{"type":"record","name":"TestRecord","namespace":"com.example","fields":[{"name":"message","type":"string"},{"name":"timestamp","type":"long"}]}","ts":1763597024561,"deleted":false}
-    parsed = JSON.parse(body)
-    if parsed.is_a?(Hash) && parsed.has_key?('schema')
-      parsed['schema']
-    else
-      # fallback to use the response as it is
-      body
-    end
-  rescue JSON::ParserError
-    # Not JSON, return as-is (probably a direct schema)
-    body
   ensure
     client.close if client
   end

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -123,7 +123,7 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
   config :ssl_keystore_password, :validate => :password
 
   # Keystore type (jks or pkcs12)
-  config :ssl_keystore_type, :validate => %w[pkcs12 jks]
+  config :ssl_keystore_type, :validate => %w[jks pkcs12]
 
   # The truststore path
   config :ssl_truststore_path, :validate => :path
@@ -281,7 +281,6 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     raise_config_error! "`ssl_key` is not allowed unless `ssl_certificate` is specified" if @ssl_key && !@ssl_certificate
     ensure_readable_and_non_writable! "ssl_key", @ssl_key if @ssl_key
 
-    raise_config_error! "`ssl_keystore_path` requires `ssl_keystore_password`" if @ssl_keystore_path && !@ssl_keystore_password
     raise_config_error! "`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified" if @ssl_keystore_password && !@ssl_keystore_path
     raise_config_error! "`ssl_keystore_password` cannot be empty" if @ssl_keystore_password && @ssl_keystore_password.value.empty?
     raise_config_error! "`ssl_keystore_type` is not allowed unless `ssl_keystore_path` is specified" if @ssl_keystore_type && !@ssl_keystore_path
@@ -297,7 +296,6 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
     end
 
     raise_config_error! "`ssl_truststore_path` and `ssl_certificate_authorities` cannot be used together." if @ssl_truststore_path && @ssl_certificate_authorities
-    raise_config_error! "`ssl_truststore_path` requires `ssl_truststore_password`" if @ssl_truststore_path && !@ssl_truststore_password
     ensure_readable_and_non_writable! "ssl_truststore_path", @ssl_truststore_path if @ssl_truststore_path
 
     raise_config_error! "`ssl_truststore_password` is not allowed unless `ssl_truststore_path` is specified" if !@ssl_truststore_path && @ssl_truststore_password

--- a/lib/logstash/codecs/avro.rb
+++ b/lib/logstash/codecs/avro.rb
@@ -267,13 +267,13 @@ class LogStash::Codecs::Avro < LogStash::Codecs::Base
 
       # retry block
       retry_count += 1
-      if retry_count <= max_retries
-        backoff_time = 2 ** (retry_count - 1)  # Exponential backoff: 1s, 2s, 4s
+      if retry_count < max_retries
+        backoff_time = 2 ** (retry_count)  # Exponential backoff: 1s, 2s, 4s
         @logger.warn("Attempt #{retry_count}/#{max_retries} failed for #{uri_string}: #{e.class} - #{e.message}. Retrying in #{backoff_time}s...")
         sleep(backoff_time)
         retry
       else
-        @logger.error("Failed to fetch schema from #{uri_string} after #{max_retries + 1} attempts: #{e.class} - #{e.message}")
+        @logger.error("Failed to fetch schema from #{uri_string} after #{max_retries} attempts: #{e.class} - #{e.message}")
         raise
       end
     end

--- a/logstash-codec-avro.gemspec
+++ b/logstash-codec-avro.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-avro'
-  s.version         = '3.4.1'
+  s.version         = '3.5.0'
   s.platform        = 'java'
   s.licenses        = ['Apache-2.0']
   s.summary         = "Reads serialized Avro records as Logstash events"
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "avro", "~> 1.10.2" #(Apache 2.0 license)
+  s.add_runtime_dependency "manticore", '>= 0.8.0', '< 1.0.0'
   s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
   s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -198,8 +198,11 @@ describe "Avro Codec Integration Tests", :integration => true do
       it "fails with invalid credentials" do
         expect {
           invalid_config = { 'schema_uri' => full_schema_url, 'username' => 'invalid', 'password' => 'wrong' }
-          LogStash::Codecs::Avro.new(invalid_config).tap { |c| c.register }
-        }.to raise_error(/401 Unauthorized/)
+          codec = LogStash::Codecs::Avro.new(invalid_config)
+          codec.register
+        }.to raise_error { |error|
+          expect(error.message).to include("401 - Unauthorized")
+        }
       end
     end
   end
@@ -237,7 +240,7 @@ describe "Avro Codec Integration Tests", :integration => true do
                         'ssl_enabled' => true,
                         'ssl_truststore_path' => truststore_path,
                         'ssl_truststore_password' => truststore_password,
-                        'ssl_truststore_type' => 'JKS',
+                        'ssl_truststore_type' => 'jks',
                         'ssl_verification_mode' => 'full'
                       })
       end
@@ -322,7 +325,7 @@ describe "Avro Codec Integration Tests", :integration => true do
                         'ssl_enabled' => true,
                         'ssl_truststore_path' => truststore_path,
                         'ssl_truststore_password' => truststore_password,
-                        'ssl_truststore_type' => 'JKS',
+                        'ssl_truststore_type' => 'jks',
                         'ssl_verification_mode' => 'full'
                       })
       end
@@ -396,10 +399,10 @@ describe "Avro Codec Integration Tests", :integration => true do
                         'ssl_enabled' => true,
                         'ssl_keystore_path' => keystore_path,
                         'ssl_keystore_password' => keystore_password,
-                        'ssl_keystore_type' => 'JKS',
+                        'ssl_keystore_type' => 'jks',
                         'ssl_truststore_path' => truststore_path,
                         'ssl_truststore_password' => truststore_password,
-                        'ssl_truststore_type' => 'JKS',
+                        'ssl_truststore_type' => 'jks',
                         'ssl_verification_mode' => 'full'
                       })
       end

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -47,6 +47,20 @@ describe "Avro Codec Integration Tests", :integration => true do
     Base64.strict_encode64(buffer.string)
   end
 
+  def decode_with_codec(codec, encoded_data)
+    events = []
+    codec.decode(encoded_data) do |event|
+      events << event
+    end
+    events
+  end
+
+  def expect_decoded_event_matches(events, expected_data)
+    expect(events.size).to eq(1)
+    expect(events.first.get("message")).to eq(expected_data["message"])
+    expect(events.first.get("timestamp")).to eq(expected_data["timestamp"])
+  end
+
   def wait_for_schema_registry(url, username: nil, password: nil, ssl_options: {})
     client_options = {}
 
@@ -100,14 +114,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       it "fetches and decodes schema from Schema Registry" do
         encoded_data = encode_avro_data(test_schema_json, test_event_data)
-        events = []
-        codec.decode(encoded_data) do |event|
-          events << event
-        end
-
-        expect(events.size).to eq(1)
-        expect(events.first.get("message")).to eq(test_event_data["message"])
-        expect(events.first.get("timestamp")).to eq(test_event_data["timestamp"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
 
       it "encodes data using schema from schema registry" do
@@ -122,12 +130,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
         expect(encoded_data).not_to be_nil
 
-        events = []
-        codec.decode(encoded_data) do |decoded_event|
-          events << decoded_event
-        end
-
-        expect(events.first.get("message")).to eq(test_event_data["message"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
     end
   end
@@ -165,13 +169,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       it "fetches schema with valid credentials" do
         encoded_data = encode_avro_data(test_schema_json, test_event_data)
-        events = []
-        codec.decode(encoded_data) do |event|
-          events << event
-        end
-
-        expect(events.size).to eq(1)
-        expect(events.first.get("message")).to eq(test_event_data["message"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
 
       it "encodes data with authentication" do
@@ -267,13 +266,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       it "fetches schema using truststore" do
         encoded_data = encode_avro_data(test_schema_json, test_event_data)
-        events = []
-        codec.decode(encoded_data) do |event|
-          events << event
-        end
-
-        expect(events.size).to eq(1)
-        expect(events.first.get("message")).to eq(test_event_data["message"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
     end
 
@@ -302,13 +296,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       it "fetches schema using CA certificate" do
         encoded_data = encode_avro_data(test_schema_json, test_event_data)
-        events = []
-        codec.decode(encoded_data) do |event|
-          events << event
-        end
-
-        expect(events.size).to eq(1)
-        expect(events.first.get("message")).to eq(test_event_data["message"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
     end
   end
@@ -376,13 +365,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       it "fetches schema with both authentication and SSL" do
         encoded_data = encode_avro_data(test_schema_json, test_event_data)
-        events = []
-        codec.decode(encoded_data) do |event|
-          events << event
-        end
-
-        expect(events.size).to eq(1)
-        expect(events.first.get("message")).to eq(test_event_data["message"])
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
 
       it "encodes data with authentication and SSL" do

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -1,0 +1,186 @@
+# encoding: utf-8
+require 'logstash/devutils/rspec/spec_helper'
+require 'logstash/codecs/avro'
+require 'logstash/event'
+require 'avro'
+require 'base64'
+require 'manticore'
+
+describe "Avro Codec Integration Tests", :integration => true do
+  INTEGRATION_DIR = File.expand_path('../', __FILE__)
+
+  let(:test_schema) do
+    {
+      "type" => "record",
+      "name" => "TestRecord",
+      "namespace" => "com.example",
+      "fields" => [
+        { "name" => "message", "type" => "string" },
+        { "name" => "timestamp", "type" => "long" }
+      ]
+    }
+  end
+
+  let(:test_schema_json) { test_schema.to_json }
+  let(:test_event_data) do
+    {
+      "message" => "test message",
+      "timestamp" => Time.now.to_i
+    }
+  end
+
+  let(:config) {{ }}
+  let(:codec) { LogStash::Codecs::Avro.new(config).tap { |c| c.register } }
+
+  def run_integration_script(script_name)
+    Dir.chdir(INTEGRATION_DIR) do
+      result = system("./#{script_name}")
+      puts "Script #{script_name} #{result ? 'succeeded' : 'failed'}"
+      result
+    end
+  end
+
+  def register_schema(schema_registry_url, schema_json, username: nil, password: nil, ssl_options: {})
+    client_options = {}
+
+    if username && password
+      client_options[:auth] = { user: username, password: password }
+    end
+
+    client_options[:ssl] = ssl_options unless ssl_options.empty?
+
+    client = Manticore::Client.new(client_options)
+
+    response = client.post("#{schema_registry_url}/subjects/test-value/versions",
+                           headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                           body: { schema: schema_json }.to_json
+    ).call
+
+    raise "Failed to register schema: #{response.code} #{response.body}" unless response.code == 200
+
+    JSON.parse(response.body)["id"]
+  ensure
+    client&.close
+  end
+
+  def encode_avro_data(schema_json, data)
+    schema = Avro::Schema.parse(schema_json)
+    dw = Avro::IO::DatumWriter.new(schema)
+    buffer = StringIO.new
+    encoder = Avro::IO::BinaryEncoder.new(buffer)
+    dw.write(data, encoder)
+    Base64.strict_encode64(buffer.string)
+  end
+
+  def create_test_schema_file(filename = "test_schema.avsc")
+    schema_path = File.join(Dir.tmpdir, filename)
+    File.write(schema_path, test_schema_json)
+    schema_path
+  end
+
+  def wait_for_schema_registry(url, timeout: 60, username: nil, password: nil, ssl_options: {})
+    start_time = Time.now
+    client_options = {}
+
+    if username && password
+      client_options[:auth] = { user: username, password: password }
+    end
+
+    client_options[:ssl] = ssl_options unless ssl_options.empty?
+
+    puts "Waiting for Schema Registry at #{url}..."
+    attempt = 0
+
+    loop do
+      attempt += 1
+      begin
+        client = Manticore::Client.new(client_options)
+        response = client.get(url).call
+        if response.code == 200
+          puts "✓ Schema Registry is ready after #{attempt} attempts"
+          return true
+        end
+      rescue => e
+        # Continue waiting
+        puts "  Attempt #{attempt}: #{e.class.name} - #{e.message[0..80]}" if attempt % 5 == 0
+      ensure
+        client&.close if client
+      end
+
+      if Time.now - start_time > timeout
+        raise "Schema Registry at #{url} did not become available within #{timeout} seconds after #{attempt} attempts"
+      end
+
+      sleep 2
+    end
+  end
+
+  context "Schema Registry without authentication" do
+    let(:schema_registry_url) { "http://localhost:8081" }
+
+    before(:all) do
+      run_integration_script("start_schema_registry.sh")
+      wait_for_schema_registry("http://localhost:8081")
+    end
+
+    after(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+    end
+
+    context "fetching schema via HTTP" do
+      let(:schema_subject) { "test-no-auth-#{Time.now.to_i}" }
+      let(:full_schema_url) do
+        url = "#{schema_registry_url}/subjects/#{schema_subject}/versions/latest"
+        puts "Constructed schema URL: #{url}"
+        raise "Schema URL is empty!" if url.nil? || url.empty? || !url.start_with?('http')
+        url
+      end
+
+      let(:config) { super().merge({'schema_uri' => full_schema_url}) }
+
+      before do
+        client = Manticore::Client.new
+        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        puts "Schema registration response: #{response.code}"
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fetches and decodes schema from Schema Registry" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = []
+        codec.decode(encoded_data) do |event|
+          events << event
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+        expect(events.first.get("timestamp")).to eq(test_event_data["timestamp"])
+      end
+
+      it "encodes data using schema from schema registry" do
+        event = LogStash::Event.new(test_event_data)
+        encoded_data = nil
+
+        codec.on_event do |e, data|
+          encoded_data = data
+        end
+
+        codec.encode(event)
+
+        expect(encoded_data).not_to be_nil
+
+        events = []
+        codec.decode(encoded_data) do |decoded_event|
+          events << decoded_event
+        end
+
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+    end
+  end
+end

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -38,29 +38,6 @@ describe "Avro Codec Integration Tests", :integration => true do
     end
   end
 
-  def register_schema(schema_registry_url, schema_json, username: nil, password: nil, ssl_options: {})
-    client_options = {}
-
-    if username && password
-      client_options[:auth] = { user: username, password: password }
-    end
-
-    client_options[:ssl] = ssl_options unless ssl_options.empty?
-
-    client = Manticore::Client.new(client_options)
-
-    response = client.post("#{schema_registry_url}/subjects/test-value/versions",
-                           headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                           body: { schema: schema_json }.to_json
-    ).call
-
-    raise "Failed to register schema: #{response.code} #{response.body}" unless response.code == 200
-
-    JSON.parse(response.body)["id"]
-  ensure
-    client&.close
-  end
-
   def encode_avro_data(schema_json, data)
     schema = Avro::Schema.parse(schema_json)
     dw = Avro::IO::DatumWriter.new(schema)
@@ -70,14 +47,7 @@ describe "Avro Codec Integration Tests", :integration => true do
     Base64.strict_encode64(buffer.string)
   end
 
-  def create_test_schema_file(filename = "test_schema.avsc")
-    schema_path = File.join(Dir.tmpdir, filename)
-    File.write(schema_path, test_schema_json)
-    schema_path
-  end
-
-  def wait_for_schema_registry(url, timeout: 60, username: nil, password: nil, ssl_options: {})
-    start_time = Time.now
+  def wait_for_schema_registry(url, username: nil, password: nil, ssl_options: {})
     client_options = {}
 
     if username && password
@@ -87,29 +57,11 @@ describe "Avro Codec Integration Tests", :integration => true do
     client_options[:ssl] = ssl_options unless ssl_options.empty?
 
     puts "Waiting for Schema Registry at #{url}..."
-    attempt = 0
+    client = Manticore::Client.new(client_options)
 
-    loop do
-      attempt += 1
-      begin
-        client = Manticore::Client.new(client_options)
-        response = client.get(url).call
-        if response.code == 200
-          puts "✓ Schema Registry is ready after #{attempt} attempts"
-          return true
-        end
-      rescue => e
-        # Continue waiting
-        puts "  Attempt #{attempt}: #{e.class.name} - #{e.message[0..80]}" if attempt % 5 == 0
-      ensure
-        client&.close if client
-      end
-
-      if Time.now - start_time > timeout
-        raise "Schema Registry at #{url} did not become available within #{timeout} seconds after #{attempt} attempts"
-      end
-
-      sleep 2
+    Stud.try(20.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
+      response = client.get(url).call
+      expect(response.code).to eq(200)
     end
   end
 
@@ -123,7 +75,6 @@ describe "Avro Codec Integration Tests", :integration => true do
 
     after(:all) do
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
     end
 
     context "fetching schema via HTTP" do
@@ -131,7 +82,6 @@ describe "Avro Codec Integration Tests", :integration => true do
       let(:full_schema_url) do
         url = "#{schema_registry_url}/subjects/#{schema_subject}/versions/latest"
         puts "Constructed schema URL: #{url}"
-        raise "Schema URL is empty!" if url.nil? || url.empty? || !url.start_with?('http')
         url
       end
 
@@ -189,15 +139,12 @@ describe "Avro Codec Integration Tests", :integration => true do
 
     before(:all) do
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
       run_integration_script("start_auth_schema_registry.sh")
-      sleep 5
       wait_for_schema_registry("http://localhost:8081", username: "barney", password: "changeme")
     end
 
     after(:all) do
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
     end
 
     context "with valid credentials" do
@@ -259,7 +206,7 @@ describe "Avro Codec Integration Tests", :integration => true do
         expect {
           invalid_config = { 'schema_uri' => full_schema_url, 'username' => 'invalid', 'password' => 'wrong' }
           LogStash::Codecs::Avro.new(invalid_config).tap { |c| c.register }
-        }.to raise_error(/401|403|HTTP request failed/)
+        }.to raise_error(/401 Unauthorized/)
       end
     end
   end
@@ -273,9 +220,7 @@ describe "Avro Codec Integration Tests", :integration => true do
     before(:all) do
       # Ensure non-auth registry is running (it includes HTTPS on 8083)
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
       run_integration_script("start_schema_registry.sh")
-      sleep 5
 
       ssl_options = {
         truststore: File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks"),
@@ -288,7 +233,6 @@ describe "Avro Codec Integration Tests", :integration => true do
 
     after(:all) do
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
     end
 
     context "with truststore configuration" do
@@ -379,9 +323,7 @@ describe "Avro Codec Integration Tests", :integration => true do
     before(:all) do
       # Start authenticated registry (includes HTTPS)
       run_integration_script("stop_schema_registry.sh")
-      sleep 3
       run_integration_script("start_auth_schema_registry.sh")
-      sleep 10
 
       ssl_options = {
         truststore: File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks"),
@@ -394,7 +336,6 @@ describe "Avro Codec Integration Tests", :integration => true do
 
     after(:all) do
       run_integration_script("stop_schema_registry.sh")
-      sleep 2
     end
 
     context "with valid credentials and truststore" do

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -61,22 +61,35 @@ describe "Avro Codec Integration Tests", :integration => true do
     expect(events.first.get("timestamp")).to eq(expected_data["timestamp"])
   end
 
-  def wait_for_schema_registry(url, username: nil, password: nil, ssl_options: {})
+  def create_manticore_client(username: nil, password: nil, ssl_options: {})
     client_options = {}
-
     if username && password
       client_options[:auth] = { user: username, password: password }
     end
-
     client_options[:ssl] = ssl_options unless ssl_options.empty?
 
+    Manticore::Client.new(client_options)
+  end
+
+  def wait_for_schema_registry(url, username: nil, password: nil, ssl_options: {})
     puts "Waiting for Schema Registry at #{url}..."
-    client = Manticore::Client.new(client_options)
+    client = create_manticore_client(username: username, password: password, ssl_options: ssl_options)
 
     Stud.try(20.times, [Manticore::SocketException, StandardError, RSpec::Expectations::ExpectationNotMetError]) do
       response = client.get(url).call
       expect(response.code).to eq(200)
     end
+    client.close
+  end
+
+  def register_schema(base_url, subject, schema_json, username: nil, password: nil, ssl_options: {})
+    client = create_manticore_client(username: username, password: password, ssl_options: ssl_options)
+    response = client.post("#{base_url}/subjects/#{subject}/versions",
+                           headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                           body: { schema: schema_json }.to_json
+    ).call
+    expect(response.code).to eq(200)
+    client.close
   end
 
   context "Schema Registry without authentication" do
@@ -102,14 +115,7 @@ describe "Avro Codec Integration Tests", :integration => true do
       let(:config) { super().merge({ 'schema_uri' => full_schema_url }) }
 
       before do
-        client = Manticore::Client.new
-        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        puts "Schema registration response: #{response.code}"
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_url, schema_subject, test_schema_json)
       end
 
       it "fetches and decodes schema from Schema Registry" do
@@ -157,14 +163,8 @@ describe "Avro Codec Integration Tests", :integration => true do
       let(:config) { super().merge({ 'schema_uri' => full_schema_url, 'username' => username, 'password' => password }) }
 
       before do
-        client_options = { auth: { user: username, password: password } }
-        client = Manticore::Client.new(client_options)
-        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_url, schema_subject, test_schema_json,
+                       username: username, password: password)
       end
 
       it "fetches schema with valid credentials" do
@@ -191,14 +191,8 @@ describe "Avro Codec Integration Tests", :integration => true do
       let(:full_schema_url) { "#{schema_registry_url}/subjects/#{schema_subject}/versions/latest" }
 
       before do
-        client_options = { auth: { user: username, password: password } }
-        client = Manticore::Client.new(client_options)
-        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_url, schema_subject, test_schema_json,
+                       username: username, password: password)
       end
 
       it "fails with invalid credentials" do
@@ -210,7 +204,7 @@ describe "Avro Codec Integration Tests", :integration => true do
     end
   end
 
-  context "Schema Registry with SSL/TLS" do
+  context "Schema Registry with truststore configuration" do
     let(:schema_registry_https_url) { "https://localhost:8083" }
     let(:truststore_path) { File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks") }
     let(:truststore_password) { "changeit" }
@@ -255,13 +249,8 @@ describe "Avro Codec Integration Tests", :integration => true do
           truststore_type: "jks",
           verify: :default
         }
-        client = Manticore::Client.new(ssl: ssl_options)
-        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_https_url, schema_subject, test_schema_json,
+                       ssl_options: ssl_options)
       end
 
       it "fetches schema using truststore" do
@@ -285,13 +274,8 @@ describe "Avro Codec Integration Tests", :integration => true do
 
       before do
         ssl_options = { ca_file: ca_cert_path, verify: :default }
-        client = Manticore::Client.new(ssl: ssl_options)
-        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_https_url, schema_subject, test_schema_json,
+                       ssl_options: ssl_options)
       end
 
       it "fetches schema using CA certificate" do
@@ -350,17 +334,9 @@ describe "Avro Codec Integration Tests", :integration => true do
           truststore_type: "jks",
           verify: :default
         }
-        client_options = {
-          auth: { user: username, password: password },
-          ssl: ssl_options
-        }
-        client = Manticore::Client.new(client_options)
-        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
-                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
-                               body: { schema: test_schema_json }.to_json
-        ).call
-        expect(response.code).to eq(200)
-        client.close
+        register_schema(schema_registry_https_url, schema_subject, test_schema_json,
+                       username: username, password: password,
+                       ssl_options: ssl_options)
       end
 
       it "fetches schema with both authentication and SSL" do
@@ -379,6 +355,73 @@ describe "Avro Codec Integration Tests", :integration => true do
 
         codec.encode(event)
         expect(encoded_data).not_to be_nil
+      end
+    end
+  end
+
+  context "Schema Registry with keystore configuration (mutual TLS)" do
+    let(:schema_registry_https_url) { "https://localhost:8083" }
+
+    let(:truststore_path) { File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks") }
+    let(:truststore_password) { "changeit" }
+    let(:keystore_path) { File.join(INTEGRATION_DIR, "tls_repository", "schema_reg.jks") }
+    let(:keystore_password) { "changeit" }
+
+    before(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      run_integration_script("start_schema_registry_mutual.sh")
+
+      ssl_options = {
+        keystore: File.join(INTEGRATION_DIR, "tls_repository", "schema_reg.jks"),
+        keystore_password: "changeit",
+        keystore_type: "jks",
+        truststore: File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks"),
+        truststore_password: "changeit",
+        truststore_type: "jks"
+      }
+      wait_for_schema_registry("https://localhost:8083", ssl_options: ssl_options)
+    end
+
+    after(:all) do
+      run_integration_script("stop_schema_registry.sh")
+    end
+
+    context "with keystore and truststore" do
+      let(:schema_subject) { "test-mutual-tls-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_https_url}/subjects/#{schema_subject}/versions/latest" }
+
+      let(:config) do
+        super().merge({
+                        'schema_uri' => full_schema_url,
+                        'ssl_enabled' => true,
+                        'ssl_keystore_path' => keystore_path,
+                        'ssl_keystore_password' => keystore_password,
+                        'ssl_keystore_type' => 'JKS',
+                        'ssl_truststore_path' => truststore_path,
+                        'ssl_truststore_password' => truststore_password,
+                        'ssl_truststore_type' => 'JKS',
+                        'ssl_verification_mode' => 'full'
+                      })
+      end
+
+      before do
+        ssl_options = {
+          keystore: keystore_path,
+          keystore_password: keystore_password,
+          keystore_type: "jks",
+          truststore: truststore_path,
+          truststore_password: truststore_password,
+          truststore_type: "jks",
+          verify: :default
+        }
+        register_schema(schema_registry_https_url, schema_subject, test_schema_json,
+                       ssl_options: ssl_options)
+      end
+
+      it "fetches schema" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = decode_with_codec(codec, encoded_data)
+        expect_decoded_event_matches(events, test_event_data)
       end
     end
   end

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -201,7 +201,7 @@ describe "Avro Codec Integration Tests", :integration => true do
           codec = LogStash::Codecs::Avro.new(invalid_config)
           codec.register
         }.to raise_error { |error|
-          expect(error.message).to include("401 - Unauthorized")
+          expect(error.message).to include("Unauthorized")
         }
       end
     end

--- a/spec/integration/avro_integration_spec.rb
+++ b/spec/integration/avro_integration_spec.rb
@@ -20,7 +20,6 @@ describe "Avro Codec Integration Tests", :integration => true do
       ]
     }
   end
-
   let(:test_schema_json) { test_schema.to_json }
   let(:test_event_data) do
     {
@@ -28,8 +27,7 @@ describe "Avro Codec Integration Tests", :integration => true do
       "timestamp" => Time.now.to_i
     }
   end
-
-  let(:config) {{ }}
+  let(:config) { {} }
   let(:codec) { LogStash::Codecs::Avro.new(config).tap { |c| c.register } }
 
   def run_integration_script(script_name)
@@ -137,7 +135,7 @@ describe "Avro Codec Integration Tests", :integration => true do
         url
       end
 
-      let(:config) { super().merge({'schema_uri' => full_schema_url}) }
+      let(:config) { super().merge({ 'schema_uri' => full_schema_url }) }
 
       before do
         client = Manticore::Client.new
@@ -180,6 +178,282 @@ describe "Avro Codec Integration Tests", :integration => true do
         end
 
         expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+    end
+  end
+
+  context "Schema Registry with authentication" do
+    let(:schema_registry_url) { "http://localhost:8081" }
+    let(:username) { "barney" }
+    let(:password) { "changeme" }
+
+    before(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+      run_integration_script("start_auth_schema_registry.sh")
+      sleep 5
+      wait_for_schema_registry("http://localhost:8081", username: "barney", password: "changeme")
+    end
+
+    after(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+    end
+
+    context "with valid credentials" do
+      let(:schema_subject) { "test-auth-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_url}/subjects/#{schema_subject}/versions/latest" }
+      let(:config) { super().merge({ 'schema_uri' => full_schema_url, 'username' => username, 'password' => password }) }
+
+      before do
+        client_options = { auth: { user: username, password: password } }
+        client = Manticore::Client.new(client_options)
+        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fetches schema with valid credentials" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = []
+        codec.decode(encoded_data) do |event|
+          events << event
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+
+      it "encodes data with authentication" do
+        event = LogStash::Event.new(test_event_data)
+        encoded_data = nil
+
+        codec.on_event do |e, data|
+          encoded_data = data
+        end
+
+        codec.encode(event)
+        expect(encoded_data).not_to be_nil
+      end
+    end
+
+    context "with invalid credentials" do
+      let(:schema_subject) { "test-invalid-auth-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_url}/subjects/#{schema_subject}/versions/latest" }
+
+      before do
+        client_options = { auth: { user: username, password: password } }
+        client = Manticore::Client.new(client_options)
+        response = client.post("#{schema_registry_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fails with invalid credentials" do
+        expect {
+          invalid_config = { 'schema_uri' => full_schema_url, 'username' => 'invalid', 'password' => 'wrong' }
+          LogStash::Codecs::Avro.new(invalid_config).tap { |c| c.register }
+        }.to raise_error(/401|403|HTTP request failed/)
+      end
+    end
+  end
+
+  context "Schema Registry with SSL/TLS" do
+    let(:schema_registry_https_url) { "https://localhost:8083" }
+    let(:truststore_path) { File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks") }
+    let(:truststore_password) { "changeit" }
+    let(:ca_cert_path) { File.join(INTEGRATION_DIR, "tls_repository", "schema_reg_certificate.pem") }
+
+    before(:all) do
+      # Ensure non-auth registry is running (it includes HTTPS on 8083)
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+      run_integration_script("start_schema_registry.sh")
+      sleep 5
+
+      ssl_options = {
+        truststore: File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks"),
+        truststore_password: "changeit",
+        truststore_type: "jks",
+        verify: :default
+      }
+      wait_for_schema_registry("https://localhost:8083", ssl_options: ssl_options)
+    end
+
+    after(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+    end
+
+    context "with truststore configuration" do
+      let(:schema_subject) { "test-ssl-truststore-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_https_url}/subjects/#{schema_subject}/versions/latest" }
+      let(:config) do
+        super().merge({
+                        'schema_uri' => full_schema_url,
+                        'ssl_enabled' => true,
+                        'ssl_truststore_path' => truststore_path,
+                        'ssl_truststore_password' => truststore_password,
+                        'ssl_truststore_type' => 'JKS',
+                        'ssl_verification_mode' => 'full'
+                      })
+      end
+
+      before do
+        ssl_options = {
+          truststore: truststore_path,
+          truststore_password: truststore_password,
+          truststore_type: "jks",
+          verify: :default
+        }
+        client = Manticore::Client.new(ssl: ssl_options)
+        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fetches schema using truststore" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = []
+        codec.decode(encoded_data) do |event|
+          events << event
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+    end
+
+    context "with CA certificate configuration" do
+      let(:schema_subject) { "test-ssl-ca-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_https_url}/subjects/#{schema_subject}/versions/latest" }
+      let(:config) do
+        super().merge({
+                        'schema_uri' => full_schema_url,
+                        'ssl_enabled' => true,
+                        'ssl_certificate_authorities' => [ca_cert_path],
+                        'ssl_verification_mode' => 'full'
+                      })
+      end
+
+      before do
+        ssl_options = { ca_file: ca_cert_path, verify: :default }
+        client = Manticore::Client.new(ssl: ssl_options)
+        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fetches schema using CA certificate" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = []
+        codec.decode(encoded_data) do |event|
+          events << event
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+    end
+  end
+
+  context "Schema Registry with authentication and SSL" do
+    let(:schema_registry_https_url) { "https://localhost:8083" }
+    let(:username) { "barney" }
+    let(:password) { "changeme" }
+    let(:truststore_path) { File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks") }
+    let(:truststore_password) { "changeit" }
+
+    before(:all) do
+      # Start authenticated registry (includes HTTPS)
+      run_integration_script("stop_schema_registry.sh")
+      sleep 3
+      run_integration_script("start_auth_schema_registry.sh")
+      sleep 10
+
+      ssl_options = {
+        truststore: File.join(INTEGRATION_DIR, "tls_repository", "clienttruststore.jks"),
+        truststore_password: "changeit",
+        truststore_type: "jks",
+        verify: :default
+      }
+      wait_for_schema_registry("https://localhost:8083", username: "barney", password: "changeme", ssl_options: ssl_options)
+    end
+
+    after(:all) do
+      run_integration_script("stop_schema_registry.sh")
+      sleep 2
+    end
+
+    context "with valid credentials and truststore" do
+      let(:schema_subject) { "test-auth-ssl-#{Time.now.to_i}" }
+      let(:full_schema_url) { "#{schema_registry_https_url}/subjects/#{schema_subject}/versions/latest" }
+      let(:config) do
+        super().merge({
+                        'schema_uri' => full_schema_url,
+                        'username' => username,
+                        'password' => password,
+                        'ssl_enabled' => true,
+                        'ssl_truststore_path' => truststore_path,
+                        'ssl_truststore_password' => truststore_password,
+                        'ssl_truststore_type' => 'JKS',
+                        'ssl_verification_mode' => 'full'
+                      })
+      end
+
+      before do
+        ssl_options = {
+          truststore: truststore_path,
+          truststore_password: truststore_password,
+          truststore_type: "jks",
+          verify: :default
+        }
+        client_options = {
+          auth: { user: username, password: password },
+          ssl: ssl_options
+        }
+        client = Manticore::Client.new(client_options)
+        response = client.post("#{schema_registry_https_url}/subjects/#{schema_subject}/versions",
+                               headers: { "Content-Type" => "application/vnd.schemaregistry.v1+json" },
+                               body: { schema: test_schema_json }.to_json
+        ).call
+        expect(response.code).to eq(200)
+        client.close
+      end
+
+      it "fetches schema with both authentication and SSL" do
+        encoded_data = encode_avro_data(test_schema_json, test_event_data)
+        events = []
+        codec.decode(encoded_data) do |event|
+          events << event
+        end
+
+        expect(events.size).to eq(1)
+        expect(events.first.get("message")).to eq(test_event_data["message"])
+      end
+
+      it "encodes data with authentication and SSL" do
+        event = LogStash::Event.new(test_event_data)
+        encoded_data = nil
+
+        codec.on_event do |e, data|
+          encoded_data = data
+        end
+
+        codec.encode(event)
+        expect(encoded_data).not_to be_nil
       end
     end
   end

--- a/spec/integration/fixtures/jaas.config
+++ b/spec/integration/fixtures/jaas.config
@@ -1,0 +1,5 @@
+SchemaRegistry-Props {
+  org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule required
+  file="build/confluent_platform/etc/schema-registry/pwd"
+  debug="true";
+};

--- a/spec/integration/fixtures/pwd
+++ b/spec/integration/fixtures/pwd
@@ -1,0 +1,2 @@
+barney: changeme,user,developer
+admin:admin,admin

--- a/spec/integration/kafka_test_setup.sh
+++ b/spec/integration/kafka_test_setup.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+
+set -ex
+# check if KAFKA_VERSION env var is set
+if [ -n "${KAFKA_VERSION+1}" ]; then
+  echo "KAFKA_VERSION is $KAFKA_VERSION"
+else
+   KAFKA_VERSION=4.1.0
+fi
+
+KAFKA_MAJOR_VERSION="${KAFKA_VERSION%%.*}"
+
+export _JAVA_OPTIONS="-Djava.net.preferIPv4Stack=true"
+
+rm -rf build
+mkdir build
+
+echo "Setup Kafka version $KAFKA_VERSION"
+if [ ! -e "kafka_2.13-$KAFKA_VERSION.tgz" ]; then
+  echo "Kafka not present locally, downloading"
+  curl -s -o "kafka_2.13-$KAFKA_VERSION.tgz" "https://downloads.apache.org/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
+fi
+cp "kafka_2.13-$KAFKA_VERSION.tgz" "build/kafka.tgz"
+mkdir "build/kafka" && tar xzf "build/kafka.tgz" -C "build/kafka" --strip-components 1
+
+echo "Use KRaft for Kafka version $KAFKA_VERSION"
+echo "log.dirs=${PWD}/build/kafka-logs" >> build/kafka/config/server.properties
+
+build/kafka/bin/kafka-storage.sh format \
+  --cluster-id $(build/kafka/bin/kafka-storage.sh random-uuid) \
+  --config build/kafka/config/server.properties \
+  --ignore-formatted \
+  --standalone
+
+echo "Starting Kafka broker"
+build/kafka/bin/kafka-server-start.sh -daemon "build/kafka/config/server.properties" --override advertised.host.name=127.0.0.1 --override log.dirs="${PWD}/build/kafka-logs"
+sleep 10
+
+echo "Setup Confluent Platform"
+# check if CONFLUENT_VERSION env var is set
+if [ -n "${CONFLUENT_VERSION+1}" ]; then
+  echo "CONFLUENT_VERSION is $CONFLUENT_VERSION"
+else
+   CONFLUENT_VERSION=8.0.0
+fi
+if [ ! -e "confluent-community-$CONFLUENT_VERSION.tar.gz" ]; then
+  echo "Confluent Platform not present locally, downloading"
+  CONFLUENT_MINOR=$(echo "$CONFLUENT_VERSION" | sed -n 's/^\([[:digit:]]*\.[[:digit:]]*\)\.[[:digit:]]*$/\1/p')
+  echo "CONFLUENT_MINOR is $CONFLUENT_MINOR"
+  curl -s -o "confluent-community-$CONFLUENT_VERSION.tar.gz" "http://packages.confluent.io/archive/$CONFLUENT_MINOR/confluent-community-$CONFLUENT_VERSION.tar.gz"
+fi
+echo "Extracting confluent-community-$CONFLUENT_VERSION.tar.gz to build"
+mkdir "build/confluent_platform" && tar xzf "confluent-community-$CONFLUENT_VERSION.tar.gz" -C "build/confluent_platform" --strip-components 1
+
+echo "Configuring TLS on Schema registry"
+rm -Rf tls_repository
+mkdir tls_repository
+./setup_keystore_and_truststore.sh
+# configure schema-registry to handle https on 8083 port
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' "build/confluent_platform/etc/schema-registry/schema-registry.properties"
+else
+  sed -i 's/http:\/\/0.0.0.0:8081/http:\/\/0.0.0.0:8081, https:\/\/0.0.0.0:8083/g' "build/confluent_platform/etc/schema-registry/schema-registry.properties"
+fi
+echo "ssl.keystore.location=`pwd`/tls_repository/schema_reg.jks" >> "build/confluent_platform/etc/schema-registry/schema-registry.properties"
+echo "ssl.keystore.password=changeit" >> "build/confluent_platform/etc/schema-registry/schema-registry.properties"
+echo "ssl.key.password=changeit" >> "build/confluent_platform/etc/schema-registry/schema-registry.properties"
+
+cp "build/confluent_platform/etc/schema-registry/schema-registry.properties" "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
+echo "authentication.method=BASIC" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
+echo "authentication.roles=admin,developer,user,sr-user" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
+echo "authentication.realm=SchemaRegistry-Props" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
+cp fixtures/jaas.config "build/confluent_platform/etc/schema-registry"
+
+echo "Setting up a test topic"
+build/kafka/bin/kafka-topics.sh --create --partitions 3 --replication-factor 1 --topic logstash_integration_topic_plain --bootstrap-server localhost:9092
+
+cp fixtures/pwd "build/confluent_platform/etc/schema-registry"
+echo "Setup complete, running specs"

--- a/spec/integration/kafka_test_setup.sh
+++ b/spec/integration/kafka_test_setup.sh
@@ -67,6 +67,11 @@ echo "ssl.keystore.location=`pwd`/tls_repository/schema_reg.jks" >> "build/confl
 echo "ssl.keystore.password=changeit" >> "build/confluent_platform/etc/schema-registry/schema-registry.properties"
 echo "ssl.key.password=changeit" >> "build/confluent_platform/etc/schema-registry/schema-registry.properties"
 
+cp "build/confluent_platform/etc/schema-registry/schema-registry.properties" "build/confluent_platform/etc/schema-registry/schema-registry-mutual.properties"
+echo "ssl.truststore.location=`pwd`/tls_repository/clienttruststore.jks" >> "build/confluent_platform/etc/schema-registry/schema-registry-mutual.properties"
+echo "ssl.truststore.password=changeit" >> "build/confluent_platform/etc/schema-registry/schema-registry-mutual.properties"
+echo "confluent.http.server.ssl.client.authentication=REQUIRED" >> "build/confluent_platform/etc/schema-registry/schema-registry-mutual.properties"
+
 cp "build/confluent_platform/etc/schema-registry/schema-registry.properties" "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
 echo "authentication.method=BASIC" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
 echo "authentication.roles=admin,developer,user" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"

--- a/spec/integration/kafka_test_setup.sh
+++ b/spec/integration/kafka_test_setup.sh
@@ -69,7 +69,7 @@ echo "ssl.key.password=changeit" >> "build/confluent_platform/etc/schema-registr
 
 cp "build/confluent_platform/etc/schema-registry/schema-registry.properties" "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
 echo "authentication.method=BASIC" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
-echo "authentication.roles=admin,developer,user,sr-user" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
+echo "authentication.roles=admin,developer,user" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
 echo "authentication.realm=SchemaRegistry-Props" >> "build/confluent_platform/etc/schema-registry/authed-schema-registry.properties"
 cp fixtures/jaas.config "build/confluent_platform/etc/schema-registry"
 

--- a/spec/integration/kafka_test_teardown.sh
+++ b/spec/integration/kafka_test_teardown.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Unregistering test topics"
+#build/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --delete --topic 'topic_avro.*' 2>&1
+
+echo "Stopping Kafka broker"
+build/kafka/bin/kafka-server-stop.sh
+
+if [ -f "build/kafka/bin/zookeeper-server-stop.sh" ]; then
+  echo "Stopping ZooKeeper"
+  build/kafka/bin/zookeeper-server-stop.sh
+fi
+
+echo "Clean TLS folder"
+rm -Rf tls_repository

--- a/spec/integration/kafka_test_teardown.sh
+++ b/spec/integration/kafka_test_teardown.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Setup Kafka and create test topics
 set -ex
 
 echo "Unregistering test topics"

--- a/spec/integration/setup_keystore_and_truststore.sh
+++ b/spec/integration/setup_keystore_and_truststore.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Setup Schema Registry keystore and Kafka's schema registry client's truststore
+set -ex
+
+echo "Generating schema registry key store"
+keytool -genkey -alias schema_reg -keyalg RSA -keystore tls_repository/schema_reg.jks -keypass changeit -storepass changeit  -validity 365  -keysize 2048 -dname "CN=localhost, OU=John Doe, O=Acme Inc, L=Unknown, ST=Unknown, C=IT"
+
+echo "Exporting schema registry certificate"
+keytool -exportcert -rfc -keystore tls_repository/schema_reg.jks -storepass changeit -alias schema_reg -file tls_repository/schema_reg_certificate.pem
+
+echo "Creating client's truststore and importing schema registry's certificate"
+keytool -import -trustcacerts -file tls_repository/schema_reg_certificate.pem -keypass changeit -storepass changeit -keystore tls_repository/clienttruststore.jks -noprompt

--- a/spec/integration/setup_keystore_and_truststore.sh
+++ b/spec/integration/setup_keystore_and_truststore.sh
@@ -10,3 +10,8 @@ keytool -exportcert -rfc -keystore tls_repository/schema_reg.jks -storepass chan
 
 echo "Creating client's truststore and importing schema registry's certificate"
 keytool -import -trustcacerts -file tls_repository/schema_reg_certificate.pem -keypass changeit -storepass changeit -keystore tls_repository/clienttruststore.jks -noprompt
+
+# make files read only
+chmod 444 tls_repository/schema_reg.jks
+chmod 444 tls_repository/schema_reg_certificate.pem
+chmod 444 tls_repository/clienttruststore.jks

--- a/spec/integration/start_auth_schema_registry.sh
+++ b/spec/integration/start_auth_schema_registry.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Setup Kafka and create test topics
 set -ex
 
 echo "Starting authed SchemaRegistry"

--- a/spec/integration/start_auth_schema_registry.sh
+++ b/spec/integration/start_auth_schema_registry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Starting authed SchemaRegistry"
+SCHEMA_REGISTRY_OPTS="-Djava.security.auth.login.config=build/confluent_platform/etc/schema-registry/jaas.config" \
+  build/confluent_platform/bin/schema-registry-start \
+  build/confluent_platform/etc/schema-registry/authed-schema-registry.properties \
+  > /dev/null 2>&1 &

--- a/spec/integration/start_schema_registry.sh
+++ b/spec/integration/start_schema_registry.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Starting SchemaRegistry"
+build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/schema-registry.properties > /dev/null 2>&1 &

--- a/spec/integration/start_schema_registry.sh
+++ b/spec/integration/start_schema_registry.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Setup Kafka and create test topics
 set -ex
 
 echo "Starting SchemaRegistry"

--- a/spec/integration/start_schema_registry_mutual.sh
+++ b/spec/integration/start_schema_registry_mutual.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+echo "Starting SchemaRegistry"
+build/confluent_platform/bin/schema-registry-start build/confluent_platform/etc/schema-registry/schema-registry-mutual.properties > /dev/null 2>&1 &

--- a/spec/integration/stop_schema_registry.sh
+++ b/spec/integration/stop_schema_registry.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Setup Kafka and create test topics
+set -ex
+
+echo "Stopping SchemaRegistry"
+build/confluent_platform/bin/schema-registry-stop
+sleep 5

--- a/spec/integration/stop_schema_registry.sh
+++ b/spec/integration/stop_schema_registry.sh
@@ -4,4 +4,4 @@ set -ex
 
 echo "Stopping SchemaRegistry"
 build/confluent_platform/bin/schema-registry-stop
-sleep 5
+sleep 2

--- a/spec/integration/stop_schema_registry.sh
+++ b/spec/integration/stop_schema_registry.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Setup Kafka and create test topics
 set -ex
 
 echo "Stopping SchemaRegistry"

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -436,6 +436,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           end
 
           it "defaults to 'full'" do
+            subject.send(:validate_ssl_settings!)
             expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
           end
         end

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -335,10 +335,564 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
       end
 
       context "secured connection against schema registry" do
+        let(:test_schema) do
+          '{"type": "record", "name": "Test",
+         "fields": [{"name": "foo", "type": ["null", "string"]},
+                    {"name": "bar", "type": "int"}]}'
+        end
 
-        # TODO: Add unit tests for secured connection against schema registry
-        #   - specified and inferred ssl_enabled
-        #   - use "ssl_keystore_path" => paths[:test_path] to overcome File.readable?/writable? operations
+        before do
+          allow_any_instance_of(described_class).to receive(:fetch_remote_schema).and_return(test_schema)
+          allow(File).to receive(:readable?).and_return(true)
+          allow(File).to receive(:writable?).and_return(false)
+        end
+
+        subject do
+          LogStash::Codecs::Avro.new(avro_config)
+        end
+
+        context "explicit and inferred SSL" do
+          context "with explicit ssl_enabled => true" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+                'ssl_enabled' => true
+              }
+            end
+
+            it "enables SSL" do
+              expect(subject.instance_variable_get(:@ssl_enabled)).to be true
+            end
+          end
+
+          context "with HTTPS URI (inferred ssl_enabled)" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+              }
+            end
+
+            it "automatically enables SSL for HTTPS URIs" do
+              subject.register
+              expect(subject.instance_variable_get(:@ssl_enabled)).to be true
+            end
+          end
+
+          context "with explicit ssl_enabled => false" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+                'ssl_enabled' => false
+              }
+            end
+
+            it "disables SSL" do
+              expect(subject.instance_variable_get(:@ssl_enabled)).to be false
+            end
+          end
+        end
+
+        context "SSL verification" do
+          context "with ssl_verification_mode => 'full'" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_verification_mode' => 'full'
+              }
+            end
+
+            it "sets verification mode to full" do
+              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
+            end
+
+            it "builds SSL options with default verify mode" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:verify]).to eq(:default)
+            end
+          end
+
+          context "with ssl_verification_mode => 'none'" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_verification_mode' => 'none'
+              }
+            end
+
+            it "sets verification mode to none" do
+              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('none')
+            end
+
+            it "builds SSL options with disable verify mode" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:verify]).to eq(:disable)
+            end
+          end
+
+          context "with default ssl_verification_mode" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+              }
+            end
+
+            it "defaults to 'full'" do
+              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
+            end
+          end
+        end
+
+        context "keystore configuration" do
+          context "with ssl_keystore_path" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_keystore_path' => paths[:test_path],
+                'ssl_keystore_password' => 'keystore_pass',
+                'ssl_keystore_type' => 'JKS'
+              }
+            end
+
+            it "configures keystore options" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:keystore]).to eq(paths[:test_path])
+              expect(ssl_options[:keystore_password]).to eq('keystore_pass')
+              expect(ssl_options[:keystore_type]).to eq('jks')
+            end
+          end
+
+          context "with ssl_keystore_path and PKCS12 type" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_keystore_path' => paths[:test_path],
+                'ssl_keystore_password' => 'keystore_pass',
+                'ssl_keystore_type' => 'PKCS12'
+              }
+            end
+
+            it "configures PKCS12 keystore" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:keystore_type]).to eq('pkcs12')
+            end
+          end
+
+          context "with ssl_keystore_path but no password" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_keystore_path' => paths[:test_path],
+              }
+            end
+
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                LogStash::ConfigurationError,
+                /`ssl_keystore_path` requires `ssl_keystore_password`/
+              )
+            end
+          end
+        end
+
+        context "truststore configuration" do
+          context "with ssl_truststore_path" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_truststore_path' => paths[:test_path],
+                'ssl_truststore_password' => 'truststore_pass',
+                'ssl_truststore_type' => 'JKS'
+              }
+            end
+
+            it "configures truststore options" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:truststore]).to eq(paths[:test_path])
+              expect(ssl_options[:truststore_password]).to eq('truststore_pass')
+              expect(ssl_options[:truststore_type]).to eq('jks')
+            end
+          end
+
+          context "with ssl_truststore_path and PKCS12 type" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_truststore_path' => paths[:test_path],
+                'ssl_truststore_password' => 'truststore_pass',
+                'ssl_truststore_type' => 'PKCS12'
+              }
+            end
+
+            it "configures PKCS12 truststore" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:truststore_type]).to eq('pkcs12')
+            end
+          end
+
+          context "with ssl_truststore_path but no password" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_truststore_path' => paths[:test_path]
+              }
+            end
+
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                LogStash::ConfigurationError,
+                /`ssl_truststore_path` requires `ssl_truststore_password`/
+              )
+            end
+          end
+        end
+
+        context "CA configuration" do
+          
+          context "with single CA file" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_certificate_authorities' => [paths[:test_path]]
+              }
+            end
+
+            it "configures CA certificate" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:ca_file]).to eq(paths[:test_path])
+            end
+          end
+
+          context "with multiple CA files" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_certificate_authorities' => [paths[:test_path], paths[:test_path]]
+              }
+            end
+
+            it "raises ConfigurationError for multiple CAs" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                LogStash::ConfigurationError,
+                /Multiple values on `ssl_certificate_authorities` are not supported/
+              )
+            end
+          end
+
+          context "with empty ssl_certificate_authorities" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_certificate_authorities' => []
+              }
+            end
+
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                LogStash::ConfigurationError,
+                /`ssl_certificate_authorities` cannot be empty/
+              )
+            end
+          end
+        end
+
+        context "cipher suites" do
+          context "with specified cipher suites" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_cipher_suites' => %w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+              }
+            end
+
+            it "configures cipher suites" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:cipher_suites]).to eq(%w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256])
+            end
+          end
+
+          context "without cipher suites" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+              }
+            end
+
+            it "does not include cipher_suites in SSL options" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options).not_to have_key(:cipher_suites)
+            end
+          end
+        end
+
+        context "supported protocols" do
+          context "with TLSv1.2 and TLSv1.3" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_supported_protocols' => %w[TLSv1.2 TLSv1.3]
+              }
+            end
+
+            it "configures supported protocols" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:protocols]).to eq(%w[TLSv1.2 TLSv1.3])
+            end
+          end
+
+          context "with only TLSv1.3" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_supported_protocols' => ['TLSv1.3']
+              }
+            end
+
+            it "configures only TLSv1.3" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options[:protocols]).to eq(['TLSv1.3'])
+            end
+          end
+
+          context "with empty ssl_supported_protocols" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_supported_protocols' => []
+              }
+            end
+
+            it "does not include protocols in SSL options" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options).not_to have_key(:protocols)
+            end
+          end
+
+          context "without ssl_supported_protocols" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+              }
+            end
+
+            it "uses default (no protocols key)" do
+              ssl_options = subject.send(:build_ssl_options)
+              expect(ssl_options).not_to have_key(:protocols)
+            end
+          end
+        end
+
+        context "SSL validations" do
+          context "PEM certificate validation" do
+            context "when both ssl_certificate and ssl_keystore_path are set" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_certificate' => paths[:test_path],
+                  'ssl_key' => paths[:test_path],
+                  'ssl_keystore_path' => paths[:test_path],
+                  'ssl_keystore_password' => 'password'
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_certificate` and `ssl_keystore_path` cannot be used together/
+                )
+              end
+            end
+
+            context "when ssl_certificate is set without ssl_key" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_certificate' => paths[:test_path]
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_certificate` requires `ssl_key`/
+                )
+              end
+            end
+
+            context "when ssl_key is set without ssl_certificate" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_key' => paths[:test_path]
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_key` is not allowed unless `ssl_certificate` is specified/
+                )
+              end
+            end
+          end
+
+          context "keystore validation" do
+            context "when ssl_keystore_password is set without ssl_keystore_path" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_keystore_password' => 'password'
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified/
+                )
+              end
+            end
+
+            context "when ssl_keystore_password is empty" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_keystore_path' => paths[:test_path],
+                  'ssl_keystore_password' => ''
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_keystore_password` cannot be empty/
+                )
+              end
+            end
+
+            context "when ssl_keystore_type is set without ssl_keystore_path" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_keystore_type' => 'JKS'
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_keystore_type` is not allowed unless `ssl_keystore_path` is specified/
+                )
+              end
+            end
+          end
+
+          context "truststore validation" do
+            context "when ssl_truststore_password is set without ssl_truststore_path" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_truststore_password' => 'password'
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_truststore_password` is not allowed unless `ssl_truststore_path` is specified/
+                )
+              end
+            end
+
+            context "when ssl_truststore_password is empty" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_truststore_path' => paths[:test_path],
+                  'ssl_truststore_password' => ''
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_truststore_password` cannot be empty/
+                )
+              end
+            end
+
+            context "when both ssl_truststore_path and ssl_certificate_authorities are set" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_truststore_path' => paths[:test_path],
+                  'ssl_truststore_password' => 'password',
+                  'ssl_certificate_authorities' => [paths[:test_path]]
+                }
+              end
+
+              it "raises ConfigurationError" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_truststore_path` and `ssl_certificate_authorities` cannot be used together/
+                )
+              end
+            end
+          end
+
+          context "verification mode validation" do
+            context "when ssl_truststore_path is set with verification mode none" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_truststore_path' => paths[:test_path],
+                  'ssl_truststore_password' => 'password',
+                  'ssl_verification_mode' => 'none'
+                }
+              end
+
+              it "requires `ssl_verification_mode` => 'full'" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_truststore_path` requires `ssl_verification_mode` to be `full`/
+                )
+              end
+            end
+
+            context "when ssl_truststore_password is set with verification mode none" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_truststore_password' => 'password',
+                  'ssl_verification_mode' => 'none'
+                }
+              end
+
+              it "requires `ssl_verification_mode => 'full'" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_truststore_password` requires `ssl_truststore_path` and `ssl_verification_mode => 'full'`/
+                )
+              end
+            end
+
+            context "when ssl_certificate_authorities is set with verification mode none" do
+              let(:avro_config) do
+                {
+                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                  'ssl_certificate_authorities' => [paths[:test_path]],
+                  'ssl_verification_mode' => 'none'
+                }
+              end
+
+              it "requires `ssl_verification_mode => 'full'" do
+                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                  LogStash::ConfigurationError,
+                  /`ssl_certificate_authorities` requires `ssl_verification_mode` to be `full`/
+                )
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -448,7 +448,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
               'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
               'ssl_keystore_path' => paths[:test_path],
               'ssl_keystore_password' => 'keystore_pass',
-              'ssl_keystore_type' => 'JKS'
+              'ssl_keystore_type' => 'jks'
             }
           end
 
@@ -460,17 +460,17 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           end
         end
 
-        context "with ssl_keystore_path and PKCS12 type" do
+        context "with ssl_keystore_path and pkcs12 type" do
           let(:avro_config) do
             {
               'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
               'ssl_keystore_path' => paths[:test_path],
               'ssl_keystore_password' => 'keystore_pass',
-              'ssl_keystore_type' => 'PKCS12'
+              'ssl_keystore_type' => 'pkcs12'
             }
           end
 
-          it "configures PKCS12 keystore" do
+          it "configures pkcs12 keystore" do
             ssl_options = subject.send(:build_ssl_options)
             expect(ssl_options[:keystore_type]).to eq('pkcs12')
           end
@@ -500,7 +500,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
               'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
               'ssl_truststore_path' => paths[:test_path],
               'ssl_truststore_password' => 'truststore_pass',
-              'ssl_truststore_type' => 'JKS'
+              'ssl_truststore_type' => 'jks'
             }
           end
 
@@ -512,17 +512,17 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           end
         end
 
-        context "with ssl_truststore_path and PKCS12 type" do
+        context "with ssl_truststore_path and pkcs12 type" do
           let(:avro_config) do
             {
               'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
               'ssl_truststore_path' => paths[:test_path],
               'ssl_truststore_password' => 'truststore_pass',
-              'ssl_truststore_type' => 'PKCS12'
+              'ssl_truststore_type' => 'pkcs12'
             }
           end
 
-          it "configures PKCS12 truststore" do
+          it "configures pkcs12 truststore" do
             ssl_options = subject.send(:build_ssl_options)
             expect(ssl_options[:truststore_type]).to eq('pkcs12')
           end
@@ -772,7 +772,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_keystore_type' => 'JKS'
+                'ssl_keystore_type' => 'jks'
               }
             end
 

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -216,8 +216,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
     end
 
     subject do
-      allow_any_instance_of(LogStash::Codecs::Avro).to \
-        receive(:fetch_remote_schema).and_return(test_schema)
+      allow_any_instance_of(LogStash::Codecs::Avro).to receive(:fetch_schema).and_return(test_schema)
       next LogStash::Codecs::Avro.new(avro_config)
     end
 
@@ -320,11 +319,6 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           }
         end
 
-        it "warns about credentials over unencrypted HTTP" do
-          expect(subject.logger).to receive(:warn).with(/Credentials are being sent over unencrypted HTTP/)
-          subject.register
-        end
-
         it "still returns valid auth hash" do
           allow(subject.logger).to receive(:warn)
           auth = subject.send(:build_basic_auth)
@@ -362,7 +356,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           end
 
           it "automatically enables SSL for HTTPS URIs" do
-            subject.register
+            subject.send(:validate_ssl_settings!)
             expect(subject.instance_variable_get(:@ssl_enabled)).to be true
           end
         end

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -8,6 +8,13 @@ require 'logstash/event'
 require 'logstash/plugin_mixins/ecs_compatibility_support/spec_helper'
 
 describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures do
+  let(:paths) do
+    {
+      # path has to be created, otherwise config :path validation fails
+      # and since we cannot control the chmod operations on paths, we should stub file readable? and writable? operations
+      :test_path => "spec/unit/resources/do_not_remove_path"
+    }
+  end
 
   ecs_compatibility_matrix(:disabled, :v1, :v8 => :v1) do |ecs_select|
     before(:each) do
@@ -24,7 +31,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
 
       subject do
         allow_any_instance_of(LogStash::Codecs::Avro).to \
-      receive(:open_and_read).and_return(avro_config['schema_uri'])
+      receive(:fetch_schema).and_return(avro_config['schema_uri'])
         next LogStash::Codecs::Avro.new(avro_config)
       end
 
@@ -177,7 +184,7 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
 
           subject do
             allow_any_instance_of(LogStash::Codecs::Avro).to \
-      receive(:open_and_read).and_return(avro_config['schema_uri'])
+      receive(:fetch_schema).and_return(avro_config['schema_uri'])
             next LogStash::Codecs::Avro.new(avro_config)
           end
 
@@ -198,6 +205,141 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
         end
       end
 
+    end
+
+    context "remote schema registry" do
+
+      context "basic authentication" do
+        let(:test_schema) do
+          '{"type": "record", "name": "Test",
+         "fields": [{"name": "foo", "type": ["null", "string"]},
+                    {"name": "bar", "type": "int"}]}'
+        end
+
+        before do
+          allow_any_instance_of(described_class).to receive(:fetch_remote_schema).and_return(test_schema)
+        end
+
+        subject do
+          LogStash::Codecs::Avro.new(avro_config)
+        end
+
+        context "with both username and password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'username' => 'test_user',
+              'password' => 'test_&^%$!password'
+            }
+          end
+
+          it "uses user and password" do
+            auth = subject.send(:build_basic_auth)
+            expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
+          end
+
+          it "includes valid credentials in auth hash" do
+            auth = subject.send(:build_basic_auth)
+            expect(auth[:user]).not_to be_empty
+            expect(auth[:password]).not_to be_empty
+          end
+        end
+
+        context "with only username" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'username' => 'test_user'
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`username` requires `password`/)
+          end
+        end
+
+        context "with only password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'password' => 'test_&^%$!password'
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`password` is not allowed unless `username` is specified/)
+          end
+        end
+
+        context "with empty username" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'username' => '',
+              'password' => 'test_&^%$!password'
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
+          end
+        end
+
+        context "with empty password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'username' => 'test_user',
+              'password' => ''
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
+          end
+        end
+
+        context "with neither username nor password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc'
+            }
+          end
+
+          it "returns empty hash" do
+            auth = subject.send(:build_basic_auth)
+            expect(auth).to be_empty
+          end
+        end
+
+        context "with unsecure connection and credentials" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'username' => 'test_user',
+              'password' => 'test_&^%$!password'
+            }
+          end
+
+          it "warns about credentials over unencrypted HTTP" do
+            expect(subject.logger).to receive(:warn).with(/Credentials are being sent over unencrypted HTTP/)
+            subject.register
+          end
+
+          it "still returns valid auth hash" do
+            allow(subject.logger).to receive(:warn)
+            auth = subject.send(:build_basic_auth)
+            expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
+          end
+        end
+      end
+
+      context "secured connection against schema registry" do
+
+        # TODO: Add unit tests for secured connection against schema registry
+        #   - specified and inferred ssl_enabled
+        #   - use "ssl_keystore_path" => paths[:test_path] to overcome File.readable?/writable? operations
+      end
     end
   end
 end

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -373,6 +373,22 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
             expect(subject.instance_variable_get(:@ssl_enabled)).to be false
           end
         end
+
+        context "with explicit ssl_enabled => true and HTTPS URI" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_enabled' => false
+            }
+          end
+
+          it "requires ssl_enabled => true" do
+            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                  LogStash::ConfigurationError,
+                                                                  /Secured https:\/\/schema-registry.example.com\/schema.avsc connection requires `ssl_enabled => true`. /
+                                                                )
+          end
+        end
       end
 
       context "SSL verification" do

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -206,690 +206,678 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
       end
 
     end
+  end
 
-    context "remote schema registry" do
-
-      context "basic authentication" do
-        let(:test_schema) do
-          '{"type": "record", "name": "Test",
+  context "remote schema registry" do
+    let(:test_schema) do
+      '{"type": "record", "name": "Test",
          "fields": [{"name": "foo", "type": ["null", "string"]},
                     {"name": "bar", "type": "int"}]}'
+    end
+
+    subject do
+      allow_any_instance_of(LogStash::Codecs::Avro).to \
+        receive(:fetch_remote_schema).and_return(test_schema)
+      next LogStash::Codecs::Avro.new(avro_config)
+    end
+
+    context "basic authentication" do
+
+      context "with both username and password" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'username' => 'test_user',
+            'password' => 'test_&^%$!password'
+          }
         end
 
-        before do
-          allow_any_instance_of(described_class).to receive(:fetch_remote_schema).and_return(test_schema)
+        it "uses user and password" do
+          auth = subject.send(:build_basic_auth)
+          expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
         end
 
-        subject do
-          LogStash::Codecs::Avro.new(avro_config)
+        it "includes valid credentials in auth hash" do
+          auth = subject.send(:build_basic_auth)
+          expect(auth[:user]).not_to be_empty
+          expect(auth[:password]).not_to be_empty
+        end
+      end
+
+      context "with only username" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'username' => 'test_user'
+          }
         end
 
-        context "with both username and password" do
+        it "raises ConfigurationError" do
+          expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`username` requires `password`/)
+        end
+      end
+
+      context "with only password" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'password' => 'test_&^%$!password'
+          }
+        end
+
+        it "raises ConfigurationError" do
+          expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`password` is not allowed unless `username` is specified/)
+        end
+      end
+
+      context "with empty username" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'username' => '',
+            'password' => 'test_&^%$!password'
+          }
+        end
+
+        it "raises ConfigurationError" do
+          expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
+        end
+      end
+
+      context "with empty password" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'username' => 'test_user',
+            'password' => ''
+          }
+        end
+
+        it "raises ConfigurationError" do
+          expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
+        end
+      end
+
+      context "with neither username nor password" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc'
+          }
+        end
+
+        it "returns empty hash" do
+          auth = subject.send(:build_basic_auth)
+          expect(auth).to be_empty
+        end
+      end
+
+      context "with unsecure connection and credentials" do
+        let(:avro_config) do
+          {
+            'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+            'username' => 'test_user',
+            'password' => 'test_&^%$!password'
+          }
+        end
+
+        it "warns about credentials over unencrypted HTTP" do
+          expect(subject.logger).to receive(:warn).with(/Credentials are being sent over unencrypted HTTP/)
+          subject.register
+        end
+
+        it "still returns valid auth hash" do
+          allow(subject.logger).to receive(:warn)
+          auth = subject.send(:build_basic_auth)
+          expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
+        end
+      end
+    end
+
+    context "secured connection against schema registry" do
+
+      before do
+        allow(File).to receive(:readable?).and_return(true)
+        allow(File).to receive(:writable?).and_return(false)
+      end
+
+      context "explicit and inferred SSL" do
+        context "with explicit ssl_enabled => true" do
           let(:avro_config) do
             {
               'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'username' => 'test_user',
-              'password' => 'test_&^%$!password'
+              'ssl_enabled' => true
             }
           end
 
-          it "uses user and password" do
-            auth = subject.send(:build_basic_auth)
-            expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
-          end
-
-          it "includes valid credentials in auth hash" do
-            auth = subject.send(:build_basic_auth)
-            expect(auth[:user]).not_to be_empty
-            expect(auth[:password]).not_to be_empty
+          it "enables SSL" do
+            expect(subject.instance_variable_get(:@ssl_enabled)).to be true
           end
         end
 
-        context "with only username" do
+        context "with HTTPS URI (inferred ssl_enabled)" do
           let(:avro_config) do
             {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'username' => 'test_user'
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
             }
           end
 
-          it "raises ConfigurationError" do
-            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`username` requires `password`/)
-          end
-        end
-
-        context "with only password" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'password' => 'test_&^%$!password'
-            }
-          end
-
-          it "raises ConfigurationError" do
-            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /`password` is not allowed unless `username` is specified/)
-          end
-        end
-
-        context "with empty username" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'username' => '',
-              'password' => 'test_&^%$!password'
-            }
-          end
-
-          it "raises ConfigurationError" do
-            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
-          end
-        end
-
-        context "with empty password" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'username' => 'test_user',
-              'password' => ''
-            }
-          end
-
-          it "raises ConfigurationError" do
-            expect { subject.send(:build_basic_auth) }.to raise_error(LogStash::ConfigurationError, /Empty `username` or `password` is not allowed/)
-          end
-        end
-
-        context "with neither username nor password" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc'
-            }
-          end
-
-          it "returns empty hash" do
-            auth = subject.send(:build_basic_auth)
-            expect(auth).to be_empty
-          end
-        end
-
-        context "with unsecure connection and credentials" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-              'username' => 'test_user',
-              'password' => 'test_&^%$!password'
-            }
-          end
-
-          it "warns about credentials over unencrypted HTTP" do
-            expect(subject.logger).to receive(:warn).with(/Credentials are being sent over unencrypted HTTP/)
+          it "automatically enables SSL for HTTPS URIs" do
             subject.register
+            expect(subject.instance_variable_get(:@ssl_enabled)).to be true
+          end
+        end
+
+        context "with explicit ssl_enabled => false" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
+              'ssl_enabled' => false
+            }
           end
 
-          it "still returns valid auth hash" do
-            allow(subject.logger).to receive(:warn)
-            auth = subject.send(:build_basic_auth)
-            expect(auth).to eq({:user => 'test_user', :password => 'test_&^%$!password'})
+          it "disables SSL" do
+            expect(subject.instance_variable_get(:@ssl_enabled)).to be false
           end
         end
       end
 
-      context "secured connection against schema registry" do
-        let(:test_schema) do
-          '{"type": "record", "name": "Test",
-         "fields": [{"name": "foo", "type": ["null", "string"]},
-                    {"name": "bar", "type": "int"}]}'
-        end
-
-        before do
-          allow_any_instance_of(described_class).to receive(:fetch_remote_schema).and_return(test_schema)
-          allow(File).to receive(:readable?).and_return(true)
-          allow(File).to receive(:writable?).and_return(false)
-        end
-
-        subject do
-          LogStash::Codecs::Avro.new(avro_config)
-        end
-
-        context "explicit and inferred SSL" do
-          context "with explicit ssl_enabled => true" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-                'ssl_enabled' => true
-              }
-            end
-
-            it "enables SSL" do
-              expect(subject.instance_variable_get(:@ssl_enabled)).to be true
-            end
+      context "SSL verification" do
+        context "with ssl_verification_mode => 'full'" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_verification_mode' => 'full'
+            }
           end
 
-          context "with HTTPS URI (inferred ssl_enabled)" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
-              }
-            end
-
-            it "automatically enables SSL for HTTPS URIs" do
-              subject.register
-              expect(subject.instance_variable_get(:@ssl_enabled)).to be true
-            end
+          it "sets verification mode to full" do
+            expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
           end
 
-          context "with explicit ssl_enabled => false" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'http://schema-registry.example.com/schema.avsc',
-                'ssl_enabled' => false
-              }
-            end
-
-            it "disables SSL" do
-              expect(subject.instance_variable_get(:@ssl_enabled)).to be false
-            end
+          it "builds SSL options with default verify mode" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:verify]).to eq(:default)
           end
         end
 
-        context "SSL verification" do
-          context "with ssl_verification_mode => 'full'" do
+        context "with ssl_verification_mode => 'none'" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_verification_mode' => 'none'
+            }
+          end
+
+          it "sets verification mode to none" do
+            expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('none')
+          end
+
+          it "builds SSL options with disable verify mode" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:verify]).to eq(:disable)
+          end
+        end
+
+        context "with default ssl_verification_mode" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+            }
+          end
+
+          it "defaults to 'full'" do
+            expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
+          end
+        end
+      end
+
+      context "keystore configuration" do
+        context "with ssl_keystore_path" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_keystore_path' => paths[:test_path],
+              'ssl_keystore_password' => 'keystore_pass',
+              'ssl_keystore_type' => 'JKS'
+            }
+          end
+
+          it "configures keystore options" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:keystore]).to eq(paths[:test_path])
+            expect(ssl_options[:keystore_password]).to eq('keystore_pass')
+            expect(ssl_options[:keystore_type]).to eq('jks')
+          end
+        end
+
+        context "with ssl_keystore_path and PKCS12 type" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_keystore_path' => paths[:test_path],
+              'ssl_keystore_password' => 'keystore_pass',
+              'ssl_keystore_type' => 'PKCS12'
+            }
+          end
+
+          it "configures PKCS12 keystore" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:keystore_type]).to eq('pkcs12')
+          end
+        end
+
+        context "with ssl_keystore_path but no password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_keystore_path' => paths[:test_path],
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                  LogStash::ConfigurationError,
+                                                                  /`ssl_keystore_path` requires `ssl_keystore_password`/
+                                                                )
+          end
+        end
+      end
+
+      context "truststore configuration" do
+        context "with ssl_truststore_path" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_truststore_path' => paths[:test_path],
+              'ssl_truststore_password' => 'truststore_pass',
+              'ssl_truststore_type' => 'JKS'
+            }
+          end
+
+          it "configures truststore options" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:truststore]).to eq(paths[:test_path])
+            expect(ssl_options[:truststore_password]).to eq('truststore_pass')
+            expect(ssl_options[:truststore_type]).to eq('jks')
+          end
+        end
+
+        context "with ssl_truststore_path and PKCS12 type" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_truststore_path' => paths[:test_path],
+              'ssl_truststore_password' => 'truststore_pass',
+              'ssl_truststore_type' => 'PKCS12'
+            }
+          end
+
+          it "configures PKCS12 truststore" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:truststore_type]).to eq('pkcs12')
+          end
+        end
+
+        context "with ssl_truststore_path but no password" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_truststore_path' => paths[:test_path]
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                  LogStash::ConfigurationError,
+                                                                  /`ssl_truststore_path` requires `ssl_truststore_password`/
+                                                                )
+          end
+        end
+      end
+
+      context "CA configuration" do
+
+        context "with single CA file" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_certificate_authorities' => [paths[:test_path]]
+            }
+          end
+
+          it "configures CA certificate" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:ca_file]).to eq(paths[:test_path])
+          end
+        end
+
+        context "with multiple CA files" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_certificate_authorities' => [paths[:test_path], paths[:test_path]]
+            }
+          end
+
+          it "raises ConfigurationError for multiple CAs" do
+            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                  LogStash::ConfigurationError,
+                                                                  /Multiple values on `ssl_certificate_authorities` are not supported/
+                                                                )
+          end
+        end
+
+        context "with empty ssl_certificate_authorities" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_certificate_authorities' => []
+            }
+          end
+
+          it "raises ConfigurationError" do
+            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                  LogStash::ConfigurationError,
+                                                                  /`ssl_certificate_authorities` cannot be empty/
+                                                                )
+          end
+        end
+      end
+
+      context "cipher suites" do
+        context "with specified cipher suites" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_cipher_suites' => %w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+            }
+          end
+
+          it "configures cipher suites" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:cipher_suites]).to eq(%w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256])
+          end
+        end
+
+        context "without cipher suites" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+            }
+          end
+
+          it "does not include cipher_suites in SSL options" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options).not_to have_key(:cipher_suites)
+          end
+        end
+      end
+
+      context "supported protocols" do
+        context "with TLSv1.2 and TLSv1.3" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_supported_protocols' => %w[TLSv1.2 TLSv1.3]
+            }
+          end
+
+          it "configures supported protocols" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:protocols]).to eq(%w[TLSv1.2 TLSv1.3])
+          end
+        end
+
+        context "with only TLSv1.3" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_supported_protocols' => ['TLSv1.3']
+            }
+          end
+
+          it "configures only TLSv1.3" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options[:protocols]).to eq(['TLSv1.3'])
+          end
+        end
+
+        context "with empty ssl_supported_protocols" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+              'ssl_supported_protocols' => []
+            }
+          end
+
+          it "does not include protocols in SSL options" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options).not_to have_key(:protocols)
+          end
+        end
+
+        context "without ssl_supported_protocols" do
+          let(:avro_config) do
+            {
+              'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+            }
+          end
+
+          it "uses default (no protocols key)" do
+            ssl_options = subject.send(:build_ssl_options)
+            expect(ssl_options).not_to have_key(:protocols)
+          end
+        end
+      end
+
+      context "SSL validations" do
+        context "PEM certificate validation" do
+          context "when both ssl_certificate and ssl_keystore_path are set" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_verification_mode' => 'full'
+                'ssl_certificate' => paths[:test_path],
+                'ssl_key' => paths[:test_path],
+                'ssl_keystore_path' => paths[:test_path],
+                'ssl_keystore_password' => 'password'
               }
             end
 
-            it "sets verification mode to full" do
-              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
-            end
-
-            it "builds SSL options with default verify mode" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:verify]).to eq(:default)
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_certificate` and `ssl_keystore_path` cannot be used together/
+                                                                  )
             end
           end
 
-          context "with ssl_verification_mode => 'none'" do
+          context "when ssl_certificate is set without ssl_key" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_verification_mode' => 'none'
+                'ssl_certificate' => paths[:test_path]
               }
             end
 
-            it "sets verification mode to none" do
-              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('none')
-            end
-
-            it "builds SSL options with disable verify mode" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:verify]).to eq(:disable)
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_certificate` requires `ssl_key`/
+                                                                  )
             end
           end
 
-          context "with default ssl_verification_mode" do
+          context "when ssl_key is set without ssl_certificate" do
             let(:avro_config) do
               {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_key' => paths[:test_path]
               }
             end
 
-            it "defaults to 'full'" do
-              expect(subject.instance_variable_get(:@ssl_verification_mode)).to eq('full')
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_key` is not allowed unless `ssl_certificate` is specified/
+                                                                  )
             end
           end
         end
 
-        context "keystore configuration" do
-          context "with ssl_keystore_path" do
+        context "keystore validation" do
+          context "when ssl_keystore_password is set without ssl_keystore_path" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_keystore_password' => 'password'
+              }
+            end
+
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified/
+                                                                  )
+            end
+          end
+
+          context "when ssl_keystore_password is empty" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
                 'ssl_keystore_path' => paths[:test_path],
-                'ssl_keystore_password' => 'keystore_pass',
+                'ssl_keystore_password' => ''
+              }
+            end
+
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_keystore_password` cannot be empty/
+                                                                  )
+            end
+          end
+
+          context "when ssl_keystore_type is set without ssl_keystore_path" do
+            let(:avro_config) do
+              {
+                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
                 'ssl_keystore_type' => 'JKS'
               }
             end
 
-            it "configures keystore options" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:keystore]).to eq(paths[:test_path])
-              expect(ssl_options[:keystore_password]).to eq('keystore_pass')
-              expect(ssl_options[:keystore_type]).to eq('jks')
+            it "raises ConfigurationError" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_keystore_type` is not allowed unless `ssl_keystore_path` is specified/
+                                                                  )
             end
           end
+        end
 
-          context "with ssl_keystore_path and PKCS12 type" do
+        context "truststore validation" do
+          context "when ssl_truststore_password is set without ssl_truststore_path" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_keystore_path' => paths[:test_path],
-                'ssl_keystore_password' => 'keystore_pass',
-                'ssl_keystore_type' => 'PKCS12'
-              }
-            end
-
-            it "configures PKCS12 keystore" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:keystore_type]).to eq('pkcs12')
-            end
-          end
-
-          context "with ssl_keystore_path but no password" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_keystore_path' => paths[:test_path],
+                'ssl_truststore_password' => 'password'
               }
             end
 
             it "raises ConfigurationError" do
               expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                LogStash::ConfigurationError,
-                /`ssl_keystore_path` requires `ssl_keystore_password`/
-              )
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_truststore_password` is not allowed unless `ssl_truststore_path` is specified/
+                                                                  )
             end
           end
-        end
 
-        context "truststore configuration" do
-          context "with ssl_truststore_path" do
+          context "when ssl_truststore_password is empty" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
                 'ssl_truststore_path' => paths[:test_path],
-                'ssl_truststore_password' => 'truststore_pass',
-                'ssl_truststore_type' => 'JKS'
-              }
-            end
-
-            it "configures truststore options" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:truststore]).to eq(paths[:test_path])
-              expect(ssl_options[:truststore_password]).to eq('truststore_pass')
-              expect(ssl_options[:truststore_type]).to eq('jks')
-            end
-          end
-
-          context "with ssl_truststore_path and PKCS12 type" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_truststore_path' => paths[:test_path],
-                'ssl_truststore_password' => 'truststore_pass',
-                'ssl_truststore_type' => 'PKCS12'
-              }
-            end
-
-            it "configures PKCS12 truststore" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:truststore_type]).to eq('pkcs12')
-            end
-          end
-
-          context "with ssl_truststore_path but no password" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_truststore_path' => paths[:test_path]
+                'ssl_truststore_password' => ''
               }
             end
 
             it "raises ConfigurationError" do
               expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                LogStash::ConfigurationError,
-                /`ssl_truststore_path` requires `ssl_truststore_password`/
-              )
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_truststore_password` cannot be empty/
+                                                                  )
             end
           end
-        end
 
-        context "CA configuration" do
-          
-          context "with single CA file" do
+          context "when both ssl_truststore_path and ssl_certificate_authorities are set" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
+                'ssl_truststore_path' => paths[:test_path],
+                'ssl_truststore_password' => 'password',
                 'ssl_certificate_authorities' => [paths[:test_path]]
               }
             end
 
-            it "configures CA certificate" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:ca_file]).to eq(paths[:test_path])
-            end
-          end
-
-          context "with multiple CA files" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_certificate_authorities' => [paths[:test_path], paths[:test_path]]
-              }
-            end
-
-            it "raises ConfigurationError for multiple CAs" do
-              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                LogStash::ConfigurationError,
-                /Multiple values on `ssl_certificate_authorities` are not supported/
-              )
-            end
-          end
-
-          context "with empty ssl_certificate_authorities" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_certificate_authorities' => []
-              }
-            end
-
             it "raises ConfigurationError" do
               expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                LogStash::ConfigurationError,
-                /`ssl_certificate_authorities` cannot be empty/
-              )
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_truststore_path` and `ssl_certificate_authorities` cannot be used together/
+                                                                  )
             end
           end
         end
 
-        context "cipher suites" do
-          context "with specified cipher suites" do
+        context "verification mode validation" do
+          context "when ssl_truststore_path is set with verification mode none" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_cipher_suites' => %w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+                'ssl_truststore_path' => paths[:test_path],
+                'ssl_truststore_password' => 'password',
+                'ssl_verification_mode' => 'none'
               }
             end
 
-            it "configures cipher suites" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:cipher_suites]).to eq(%w[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256])
+            it "requires `ssl_verification_mode` => 'full'" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_truststore_path` requires `ssl_verification_mode` to be `full`/
+                                                                  )
             end
           end
 
-          context "without cipher suites" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
-              }
-            end
-
-            it "does not include cipher_suites in SSL options" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options).not_to have_key(:cipher_suites)
-            end
-          end
-        end
-
-        context "supported protocols" do
-          context "with TLSv1.2 and TLSv1.3" do
+          context "when ssl_truststore_password is set with verification mode none" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_supported_protocols' => %w[TLSv1.2 TLSv1.3]
+                'ssl_truststore_password' => 'password',
+                'ssl_verification_mode' => 'none'
               }
             end
 
-            it "configures supported protocols" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:protocols]).to eq(%w[TLSv1.2 TLSv1.3])
+            it "requires `ssl_verification_mode => 'full'" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_truststore_password` requires `ssl_truststore_path` and `ssl_verification_mode => 'full'`/
+                                                                  )
             end
           end
 
-          context "with only TLSv1.3" do
+          context "when ssl_certificate_authorities is set with verification mode none" do
             let(:avro_config) do
               {
                 'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_supported_protocols' => ['TLSv1.3']
+                'ssl_certificate_authorities' => [paths[:test_path]],
+                'ssl_verification_mode' => 'none'
               }
             end
 
-            it "configures only TLSv1.3" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options[:protocols]).to eq(['TLSv1.3'])
-            end
-          end
-
-          context "with empty ssl_supported_protocols" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                'ssl_supported_protocols' => []
-              }
-            end
-
-            it "does not include protocols in SSL options" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options).not_to have_key(:protocols)
-            end
-          end
-
-          context "without ssl_supported_protocols" do
-            let(:avro_config) do
-              {
-                'schema_uri' => 'https://schema-registry.example.com/schema.avsc'
-              }
-            end
-
-            it "uses default (no protocols key)" do
-              ssl_options = subject.send(:build_ssl_options)
-              expect(ssl_options).not_to have_key(:protocols)
-            end
-          end
-        end
-
-        context "SSL validations" do
-          context "PEM certificate validation" do
-            context "when both ssl_certificate and ssl_keystore_path are set" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_certificate' => paths[:test_path],
-                  'ssl_key' => paths[:test_path],
-                  'ssl_keystore_path' => paths[:test_path],
-                  'ssl_keystore_password' => 'password'
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_certificate` and `ssl_keystore_path` cannot be used together/
-                )
-              end
-            end
-
-            context "when ssl_certificate is set without ssl_key" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_certificate' => paths[:test_path]
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_certificate` requires `ssl_key`/
-                )
-              end
-            end
-
-            context "when ssl_key is set without ssl_certificate" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_key' => paths[:test_path]
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_key` is not allowed unless `ssl_certificate` is specified/
-                )
-              end
-            end
-          end
-
-          context "keystore validation" do
-            context "when ssl_keystore_password is set without ssl_keystore_path" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_keystore_password' => 'password'
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_keystore_password` is not allowed unless `ssl_keystore_path` is specified/
-                )
-              end
-            end
-
-            context "when ssl_keystore_password is empty" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_keystore_path' => paths[:test_path],
-                  'ssl_keystore_password' => ''
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_keystore_password` cannot be empty/
-                )
-              end
-            end
-
-            context "when ssl_keystore_type is set without ssl_keystore_path" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_keystore_type' => 'JKS'
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_keystore_type` is not allowed unless `ssl_keystore_path` is specified/
-                )
-              end
-            end
-          end
-
-          context "truststore validation" do
-            context "when ssl_truststore_password is set without ssl_truststore_path" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_truststore_password' => 'password'
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_truststore_password` is not allowed unless `ssl_truststore_path` is specified/
-                )
-              end
-            end
-
-            context "when ssl_truststore_password is empty" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_truststore_path' => paths[:test_path],
-                  'ssl_truststore_password' => ''
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_truststore_password` cannot be empty/
-                )
-              end
-            end
-
-            context "when both ssl_truststore_path and ssl_certificate_authorities are set" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_truststore_path' => paths[:test_path],
-                  'ssl_truststore_password' => 'password',
-                  'ssl_certificate_authorities' => [paths[:test_path]]
-                }
-              end
-
-              it "raises ConfigurationError" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_truststore_path` and `ssl_certificate_authorities` cannot be used together/
-                )
-              end
-            end
-          end
-
-          context "verification mode validation" do
-            context "when ssl_truststore_path is set with verification mode none" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_truststore_path' => paths[:test_path],
-                  'ssl_truststore_password' => 'password',
-                  'ssl_verification_mode' => 'none'
-                }
-              end
-
-              it "requires `ssl_verification_mode` => 'full'" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_truststore_path` requires `ssl_verification_mode` to be `full`/
-                )
-              end
-            end
-
-            context "when ssl_truststore_password is set with verification mode none" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_truststore_password' => 'password',
-                  'ssl_verification_mode' => 'none'
-                }
-              end
-
-              it "requires `ssl_verification_mode => 'full'" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_truststore_password` requires `ssl_truststore_path` and `ssl_verification_mode => 'full'`/
-                )
-              end
-            end
-
-            context "when ssl_certificate_authorities is set with verification mode none" do
-              let(:avro_config) do
-                {
-                  'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-                  'ssl_certificate_authorities' => [paths[:test_path]],
-                  'ssl_verification_mode' => 'none'
-                }
-              end
-
-              it "requires `ssl_verification_mode => 'full'" do
-                expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                  LogStash::ConfigurationError,
-                  /`ssl_certificate_authorities` requires `ssl_verification_mode` to be `full`/
-                )
-              end
+            it "requires `ssl_verification_mode => 'full'" do
+              expect { subject.send(:validate_ssl_settings!) }.to raise_error(
+                                                                    LogStash::ConfigurationError,
+                                                                    /`ssl_certificate_authorities` requires `ssl_verification_mode` to be `full`/
+                                                                  )
             end
           end
         end

--- a/spec/unit/avro_spec.rb
+++ b/spec/unit/avro_spec.rb
@@ -475,22 +475,6 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
             expect(ssl_options[:keystore_type]).to eq('pkcs12')
           end
         end
-
-        context "with ssl_keystore_path but no password" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-              'ssl_keystore_path' => paths[:test_path],
-            }
-          end
-
-          it "raises ConfigurationError" do
-            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                                                                  LogStash::ConfigurationError,
-                                                                  /`ssl_keystore_path` requires `ssl_keystore_password`/
-                                                                )
-          end
-        end
       end
 
       context "truststore configuration" do
@@ -525,22 +509,6 @@ describe LogStash::Codecs::Avro, :ecs_compatibility_support, :aggregate_failures
           it "configures pkcs12 truststore" do
             ssl_options = subject.send(:build_ssl_options)
             expect(ssl_options[:truststore_type]).to eq('pkcs12')
-          end
-        end
-
-        context "with ssl_truststore_path but no password" do
-          let(:avro_config) do
-            {
-              'schema_uri' => 'https://schema-registry.example.com/schema.avsc',
-              'ssl_truststore_path' => paths[:test_path]
-            }
-          end
-
-          it "raises ConfigurationError" do
-            expect { subject.send(:validate_ssl_settings!) }.to raise_error(
-                                                                  LogStash::ConfigurationError,
-                                                                  /`ssl_truststore_path` requires `ssl_truststore_password`/
-                                                                )
           end
         end
       end

--- a/spec/unit/resources/do_not_remove_path/.gitignore
+++ b/spec/unit/resources/do_not_remove_path/.gitignore
@@ -1,0 +1,2 @@
+# Empty dir for test cases to run, imitates readable/non-readable/writable folder
+# When configs are :path validated, existed path is required


### PR DESCRIPTION
## Description
  - Add SSL/TLS support for HTTPS schema registry connections
    - Add `ssl_enabled` option to enable/disable SSL
    - Add `ssl_certificate` and `ssl_key` options for PEM-based client authentication (unencrypted keys only)
    - Add `ssl_certificate_authorities` option for PEM-based server certificate validation
    - Add `ssl_verification_mode` option to control SSL verification (full, none)
    - Add `ssl_cipher_suites` option to configure cipher suites
    - Add `ssl_supported_protocols` option to configure TLS protocol versions (TLSv1.1, TLSv1.2, TLSv1.3)
    - Add `ssl_truststore_path` and `ssl_truststore_password` options for server certificate validation (JKS/PKCS12)
    - Add `ssl_keystore_path` and `ssl_keystore_password` options for mutual TLS authentication (JKS/PKCS12)
    - Add `ssl_truststore_type` and `ssl_keystore_type` options (JKS or PKCS12)
  - Add HTTP proxy support with `proxy` option
  - Add HTTP basic authentication support with `username` and `password` options

Integration test environment is same as https://github.com/logstash-plugins/logstash-integration-kafka
